### PR TITLE
fix(ci): stop green-washing coverage-floor failures in suite_runner

### DIFF
--- a/infrastructure/reporting/suite_runner.py
+++ b/infrastructure/reporting/suite_runner.py
@@ -281,9 +281,20 @@ def run_test_suite(config: "TestSuiteConfig") -> tuple[int, dict[str, Any]]:
     if exit_code != 0:
         if should_halt:
             logger.error(message)
-        else:
+        elif failed_count > 0:
+            # Tolerated test failures (failed_count within the configured max):
+            # suppress the non-zero exit so the pipeline may continue.
             logger.warning(message)
             exit_code = 0
+        else:
+            # Non-zero exit with zero test failures is NOT a tolerated test
+            # failure — it is a coverage-below-floor gate failure or an internal
+            # pytest error. Suppressing it here would green-wash a failed
+            # coverage gate (every test passing while coverage < threshold).
+            logger.error(
+                f"{config.label}: non-zero exit ({exit_code}) with no test "
+                "failures — coverage gate or pytest error; not suppressed"
+            )
 
     # Keep the results dict in sync with the (possibly suppressed) exit code
     test_results["exit_code"] = exit_code

--- a/tests/infra_tests/reporting/test_pipeline_test_runner_integration.py
+++ b/tests/infra_tests/reporting/test_pipeline_test_runner_integration.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -73,16 +72,28 @@ def repo_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def _link_pipeline_smoke_paths(repo_root: Path) -> None:
-    """Symlink pipeline-smoke test paths from the workspace into a synthetic repo root."""
-    workspace = Path(__file__).resolve().parents[3]
+def _seed_pipeline_smoke_paths(repo_root: Path) -> None:
+    """Create trivial passing test files at each pipeline-smoke path.
+
+    This exercises the *runner orchestration* — smoke-path resolution
+    (``resolve_infrastructure_test_paths``), the real pytest subprocess, the
+    marker-filter expression and exit-code propagation — in a self-contained
+    synthetic repo. We deliberately do NOT symlink the real infra smoke tests:
+    they pull in ``import infrastructure.*`` plus a conftest/helper chain that a
+    synthetic repo cannot satisfy, which previously made the subprocess fail
+    collection (exit 2). That non-zero exit used to be silently green-washed to 0
+    by ``suite_runner``; with that masking removed, this test must drive the
+    runner against tests that genuinely collect and pass. The real smoke tests are
+    exercised for real by the full infrastructure suite — here we only assert the
+    runner returns success when its smoke subprocess passes.
+    """
+    body = "def test_smoke_ok() -> None:\n    assert True\n"
     for rel in PIPELINE_SMOKE_INFRA_TEST_PATHS:
-        src = workspace / rel
-        dst = repo_root / rel
-        if dst.exists() or dst.is_symlink():
-            continue
+        # File paths (``.../foo.py``) become that file; directory paths
+        # (e.g. ``git_hook_smoke``) get a single test module inside them.
+        dst = repo_root / rel if rel.suffix == ".py" else repo_root / rel / "test_smoke.py"
         dst.parent.mkdir(parents=True, exist_ok=True)
-        os.symlink(src, dst, target_is_directory=src.is_dir())
+        dst.write_text(body)
 
 
 @pytest.mark.timeout(180)
@@ -90,7 +101,7 @@ def test_run_infrastructure_tests_pipeline_smoke_real_subprocess(tmp_path: Path)
     """Pipeline-smoke scope runs real pytest subprocesses against smoke paths."""
     (tmp_path / "projects").mkdir()
     _write_minimal_project(tmp_path, "demo")
-    _link_pipeline_smoke_paths(tmp_path)
+    _seed_pipeline_smoke_paths(tmp_path)
     exit_code, results = run_infrastructure_tests(
         tmp_path,
         project_name="demo",

--- a/tests/infra_tests/reporting/test_suite_runner.py
+++ b/tests/infra_tests/reporting/test_suite_runner.py
@@ -266,3 +266,31 @@ class TestRunTestSuite:
         config = self._make_config(tmp_path, cmd=["echo", "All good"])
         exit_code, results = run_test_suite(config)
         assert isinstance(results, dict)
+
+    def test_coverage_floor_failure_is_not_green_washed(self, tmp_path):
+        """Regression: a non-zero exit with ZERO test failures (the signature of a
+        ``--cov-fail-under`` coverage-floor failure: every test passes, pytest still
+        exits 1) must NOT be suppressed to 0. Suppressing it green-washes a failed
+        coverage gate. Pins suite_runner.run_test_suite against that latent defect."""
+        config = self._make_config(
+            tmp_path,
+            # All tests pass (failed==0) but the process exits non-zero, exactly as
+            # pytest does when coverage is below --cov-fail-under.
+            cmd=["bash", "-c", "echo '10 passed in 1.0s'; exit 1"],
+        )
+        exit_code, results = run_test_suite(config)
+        assert results.get("failed", 0) == 0
+        assert exit_code == 1, "coverage-floor failure (exit 1, 0 failed) was green-washed to 0"
+
+    def test_tolerated_test_failures_are_still_suppressed(self, tmp_path, monkeypatch):
+        """Companion control: a non-zero exit WITH test failures that are within the
+        configured tolerance is still suppressed to 0 (the legitimate path the fix
+        must preserve). Uses a real env var, not a mock."""
+        monkeypatch.setenv("MAX_TEST_FAILURES", "5")
+        config = self._make_config(
+            tmp_path,
+            cmd=["bash", "-c", "echo '2 failed, 8 passed in 1.0s'; exit 1"],
+        )
+        exit_code, results = run_test_suite(config)
+        assert results.get("failed", 0) == 2
+        assert exit_code == 0, "tolerated test failures (2 <= max 5) should be suppressed"


### PR DESCRIPTION
## The defect

`infrastructure/reporting/suite_runner.py` forced `exit_code = 0` whenever `check_test_failures` returned `should_halt=False`. But that helper returns `should_halt=False` whenever `failed_count == 0` — and a `--cov-fail-under` failure is exactly *every test passing while pytest exits 1*. So **a project dropping below its coverage floor reported PASS.** (Found by Forge during the template_newspaper verification; empirically reproduced by revert-and-rerun.)

## The fix

Only suppress the non-zero exit for **tolerated test failures** (`failed_count > 0` within the configured max). A non-zero exit with **zero** test failures — coverage-floor failure or an internal pytest error — keeps its exit code.

Two regression tests pin both paths:
- `test_coverage_floor_failure_is_not_green_washed` (exit 1 + 0 failed → stays 1)
- `test_tolerated_test_failures_are_still_suppressed` (exit 1 + 2 failed, max 5 → suppressed to 0)

## Coupled fix: a previously-vacuous test

`test_run_infrastructure_tests_pipeline_smoke_real_subprocess` only passed *because of* the green-wash: its synthetic repo couldn't `import infrastructure`, so the smoke subprocess exited 2 (collection error) and was masked to 0 — it never actually ran anything. It now seeds trivial passing tests at the smoke paths, genuinely exercising the runner's path-resolution + subprocess + exit-code propagation. (Symlinking the real smoke tests cascades into a conftest/helper dependency chain a synthetic repo can't satisfy.)

## Verification (run, not asserted)

- Targeted: 32 infra tests pass (incl. both regressions + the repaired smoke test); ruff/format/mypy clean.
- **Full infra suite: 7178 passed, 0 failed** — confirms no *other* test was relying on the masking.