### PR TITLE
fix(ci): restore missing doc pairs to green main

### DIFF
--- a/projects/templates/template_active_inference/docs/reference/AGENTS.md
+++ b/projects/templates/template_active_inference/docs/reference/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Notes
+
+`projects/templates/template_active_inference/docs/reference/` is documentation
+only — reference lookups, not business logic. Keep logic in `../../src/`,
+orchestration in `../../scripts/`, and generated artifacts under `../../output/`.
+
+- **method-inventory.md** must stay in step with the methods actually defined in
+  `../../src/`; when you add or rename a method/track, update its row here.
+- **rendering-reproducibility.md** documents the deterministic render contract
+  (fixed seeds, pinned inputs); update it when the render pipeline changes.
+
+Every directory under `docs/` carries a `README.md` (user-facing) and an
+`AGENTS.md` (this technical note) — the repo's doc-pair lint enforces both.

--- a/projects/templates/template_active_inference/docs/reference/README.md
+++ b/projects/templates/template_active_inference/docs/reference/README.md
@@ -1,0 +1,13 @@
+# Reference
+
+Reference material for the Active Inference exemplar — stable lookups that
+support the manuscript and the track pipeline.
+
+- [method-inventory.md](method-inventory.md) — catalogue of the analytical /
+  pymdp / Lean / GNN / ontology methods exercised by the tracks, and where each
+  is defined in `../../src/`.
+- [rendering-reproducibility.md](rendering-reproducibility.md) — how the
+  manuscript and figures are rendered deterministically (seeds, pinned inputs,
+  regenerate-from-clean steps).
+
+See the parent [docs/README.md](../README.md) for the full documentation map.

--- a/projects/templates/template_active_inference/src/validation_spine/AGENTS.md
+++ b/projects/templates/template_active_inference/src/validation_spine/AGENTS.md
@@ -1,0 +1,15 @@
+# Source Module Notes
+
+`validation_spine/` holds the deterministic artifact contracts for the Active
+Inference exemplar. All reusable, tested logic lives here; `../../scripts/`
+(e.g. `generate_validation_spine.py`) only parses arguments, resolves paths, and
+calls these functions (thin-orchestrator pattern).
+
+- `artifacts.py` writes and validates the artifact-provenance, deterministic
+  replay, and counterexample-matrix records consumed by the gate tests before
+  manuscript/output validation.
+- Keep every contract deterministic (fixed seeds, no network, no runtime
+  downloads) so replays are byte-stable.
+- The validation spine runs ahead of manuscript/output validation; changes here
+  must keep the five tracks (prose / formalism / numerics / pymdp / Lean)
+  concordant.


### PR DESCRIPTION
## Problem
PR #11 merged with two directories missing their required `README.md`/`AGENTS.md`
pair, turning **main's CI red** (Documentation Lint job + `test_doc_pair_lint`
infra tests on Ubuntu):
- `projects/templates/template_active_inference/docs/reference/` — had only `method-inventory.md` + `rendering-reproducibility.md`
- `projects/templates/template_active_inference/src/validation_spine/` — had only `README.md`

## Fix
Add the three missing doc-pair files. Minimal, docs-only, zero logic change.

## Verification
- `scripts/lint_docs.py --quiet` → exit 0
- `pytest tests/infra_tests/validation/docs/test_doc_pair_lint.py` → 7 passed

Unblocks main. (My orphaned infra-audit/exa/layering work re-lands in a follow-up PR.)