### PR TITLE
Infrastructure composability audit: Exa client, Tier-2 fixes, core/project layering

### DIFF
--- a/docs/_generated/canonical_facts.md
+++ b/docs/_generated/canonical_facts.md
@@ -77,7 +77,7 @@ Python modules on disk:
 find infrastructure -name '*.py' -type f | wc -l
 ```
 
-(Last refreshed count: **484** on 2026-06-02 UTC — point-in-time; re-derive with the command above, the literal drifts as the tree changes.)
+(Last refreshed count: **504** on 2026-06-03 UTC — includes the `infrastructure/search/exa/` client package, `infrastructure/core/project_paths.py`, and the `__main__.py` entrypoints; point-in-time, re-derive with the command above.)
 
 See `infrastructure/AGENTS.md` for module-specific function signatures and entry points.
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -53,6 +53,7 @@ This index lists documentation files in the Research Project Template by categor
 | Logging | [operational/logging/output-design.md](operational/logging/output-design.md) | [operational/logging/python-logging.md](operational/logging/python-logging.md), [operational/logging/bash-logging.md](operational/logging/bash-logging.md) |
 | Secure / steganography | [guides/secure-research-guide.md](guides/secure-research-guide.md) | [security/README.md](security/README.md), [security/secure_execution.md](security/secure_execution.md) |
 | Literature search | [guides/literature-workflow-guide.md](guides/literature-workflow-guide.md) | [core/literature-data-flow.md](core/literature-data-flow.md), [modules/literature-search-and-references.md](modules/literature-search-and-references.md) |
+| Web search (Exa) | [modules/guides/search-module.md](modules/guides/search-module.md#exa-web-search-exa) | [../infrastructure/search/exa/CAPABILITIES.md](../infrastructure/search/exa/CAPABILITIES.md) |
 
 **Module package counts:** link [modules/modules-guide.md](modules/modules-guide.md) or regenerate from `infrastructure/` discovery — do not hand-edit competing literals across hub pages.
 
@@ -221,6 +222,8 @@ Development standards are documented in **`docs/rules/`**. The Cursor IDE entry 
 - **[modules/guides/prose-module.md](modules/guides/prose-module.md)**
 - **[modules/guides/search-module.md](modules/guides/search-module.md)**
 - **[modules/guides/reference-module.md](modules/guides/reference-module.md)**
+- **[modules/guides/methods-module.md](modules/guides/methods-module.md)**
+- **[modules/guides/sia-module.md](modules/guides/sia-module.md)**
 
 ---
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -223,7 +223,6 @@ Development standards are documented in **`docs/rules/`**. The Cursor IDE entry 
 - **[modules/guides/search-module.md](modules/guides/search-module.md)**
 - **[modules/guides/reference-module.md](modules/guides/reference-module.md)**
 - **[modules/guides/methods-module.md](modules/guides/methods-module.md)**
-- **[modules/guides/sia-module.md](modules/guides/sia-module.md)**
 
 ---
 

--- a/docs/modules/guides/search-module.md
+++ b/docs/modules/guides/search-module.md
@@ -1,8 +1,8 @@
 # Search Module
 
-> **Academic literature discovery — multi-source search, deterministic caching, full-text enrichment.**
+> **Two search interfaces: `literature/` — academic discovery (multi-source, deterministic caching, full-text enrichment); `exa/` — general web search, content extraction, and grounded answers via the Exa API.**
 
-**Location:** `infrastructure/search/`
+**Location:** `infrastructure/search/` (subpackages: `literature/`, `exa/`)
 **Quick Reference:** [Modules Guide](../modules-guide.md) | [Literature Workflow](../../guides/literature-workflow-guide.md) | [Code Review Checklist](../../development/code-review-checklist.md)
 
 ---
@@ -15,7 +15,39 @@
 - **Full-text** — `AbstractFetcher`, `FulltextFetcher` retrieve abstracts and PDFs where licensing permits.
 - **Corpus export** — `write_corpus()` produces a stable on-disk corpus suitable for downstream LLM synthesis.
 
-This module is the **discovery side** of the literature workflow; the export side (BibTeX) lives in [`reference`](reference-module.md).
+This is the **discovery side** of the literature workflow; the export side (BibTeX) lives in [`reference`](reference-module.md).
+
+---
+
+## Exa Web Search (`exa/`)
+
+A self-contained, stdlib-only client for the [Exa](https://exa.ai) search API —
+the general-web sibling to `literature/`. One normalised `ExaResult` record is
+returned across every endpoint, so results and citations are consumed uniformly.
+
+- **Four interfaces** — `search` (`POST /search`, neural/keyword retrieval +
+  `output_schema` structured synthesis), `contents` (`POST /contents`, parsed
+  text for known URLs), `answer` (`POST /answer`, grounded answer + citations),
+  `find_similar` (`POST /findSimilar`, similar pages for a seed URL).
+- **Construction** — `ExaClient.from_env()` reads `EXA_API_KEY` from the
+  environment (never at import time; no `.env` autoload). Tests inject a
+  `pytest-httpserver` transport via `base_url` — no mocks.
+- **What you can extract** — ranked URLs, query-relevant highlights, full text
+  (RAG), **named entities with field-level citations + confidence**
+  (`output_schema` grounding), cited natural-language answers, similarity
+  scores, and per-call `cost_dollars`.
+- **CLI** — `python -m infrastructure.search.exa {search,contents,answer,find-similar} …`.
+
+```python
+from infrastructure.search.exa import ExaClient
+client = ExaClient.from_env()
+resp = client.search("vector database benchmarks", num_results=5)   # highlights by default
+```
+
+Full method reference (params, return shapes, live-confirmed examples, costs):
+[`infrastructure/search/exa/CAPABILITIES.md`](../../../infrastructure/search/exa/CAPABILITIES.md).
+camelCase on the wire, snake_case in Python; content keys nest under `contents`
+for `/search` and `/findSimilar` but are top-level for `/contents`.
 
 ---
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -923,7 +923,7 @@ Information about a discovered project.
 
 ### `resolve_project_root`
 
-*function — defined in `infrastructure.project.discovery`*
+*function — defined in `infrastructure.core.project_paths`*
 
 ```python
 resolve_project_root(repo_root: Path | str, project_name: str) -> Path

--- a/infrastructure/benchmark/template_smoke_manifest.json
+++ b/infrastructure/benchmark/template_smoke_manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "template-smoke",
   "projects": [
-    "template_code_project",
-    "template_prose_project"
+    "templates/template_code_project",
+    "templates/template_prose_project"
   ],
   "required_outputs": [
     "output/pdf",

--- a/infrastructure/core/analysis_pipeline.py
+++ b/infrastructure/core/analysis_pipeline.py
@@ -28,7 +28,7 @@ from infrastructure.core.logging.utils import (
 )
 from infrastructure.core.progress import SubStageProgress
 from infrastructure.core.runtime.environment import build_analysis_script_cmd_and_env
-from infrastructure.project.discovery import resolve_project_root
+from infrastructure.core.project_paths import resolve_project_root
 
 logger = get_logger(__name__)
 

--- a/infrastructure/core/files/operations.py
+++ b/infrastructure/core/files/operations.py
@@ -161,7 +161,7 @@ def copy_final_deliverables(
     logger.info(f"Copying all outputs for project '{project_name}'...")
 
     if project_dir is None:
-        from infrastructure.project.discovery import resolve_project_root
+        from infrastructure.core.project_paths import resolve_project_root
 
         project_dir = resolve_project_root(project_root, project_name)
     project_output = project_dir / "output"

--- a/infrastructure/core/project_paths.py
+++ b/infrastructure/core/project_paths.py
@@ -1,0 +1,84 @@
+"""Project-path resolution primitives — the foundation layer's view of ``projects/``.
+
+These are pure ``pathlib`` helpers with no dependency on the higher-level
+``infrastructure.project`` package, so true-foundation modules
+(``core.files``, ``core.runtime``) can resolve project directories without the
+foundation importing upward into ``project`` (which would create a
+``core ↔ project`` layering cycle). ``infrastructure.project.discovery``
+re-exports these names, so existing ``from infrastructure.project.discovery
+import resolve_project_root`` call sites keep working unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: Typed subfolders under ``projects/`` that hold non-rendered lifecycle mirrors.
+#: Their nested projects are deliberately excluded from discovery so they never
+#: enter the render set. Only ``templates/`` (public exemplars) and ``active/``
+#: (the hot seat) are discovered. Keep in sync with
+#: :data:`infrastructure.project.linking.LIFECYCLE_LINK_DIRS`.
+NON_RENDERED_SUBDIRS: frozenset[str] = frozenset({"working", "published", "archive", "other"})
+
+
+def resolve_project_root(repo_root: Path | str, project_name: str) -> Path:
+    """Return the directory for *project_name*, preferring the hot seat over WIP trees.
+
+    Use this when a tool should find a work-in-progress tree (for example COGANT) that has not
+    been promoted to ``projects/active/`` yet. If ``projects/active/<project_name>`` exists and
+    looks like a project source tree, that path wins; otherwise
+    ``projects/working/<project_name>`` is used when present, then a flat
+    standalone ``projects/<project_name>`` tree. A skeletal generated-output
+    directory does not shadow an actual WIP source tree.
+
+    If none of those exist, returns ``projects/active/<project_name>`` so callers get a
+    stable path for error messages.
+
+    Args:
+        repo_root: Repository root (directory containing ``infrastructure/``).
+        project_name: Final path segment (e.g. ``"cogant"``).
+
+    Returns:
+        Absolute resolved path to the project directory.
+    """
+    if isinstance(repo_root, str):
+        repo_root = Path(repo_root)
+
+    def has_project_markers(path: Path) -> bool:
+        return any((path / marker).exists() for marker in ("src", "tests", "scripts", "manuscript"))
+
+    # A name that already carries a typed-subfolder prefix (e.g. ``active/demo``,
+    # ``working/draft``, ``templates/template_code_project``) is resolved directly
+    # under ``projects/`` without re-prepending the hot-seat prefix.
+    head = project_name.replace("\\", "/").split("/", 1)[0]
+    if head in (NON_RENDERED_SUBDIRS | {"active", "templates"}):
+        qualified = repo_root / "projects" / project_name
+        if qualified.is_dir():
+            return qualified.resolve()
+        return qualified
+
+    primary = repo_root / "projects" / "active" / project_name
+    if primary.is_dir() and has_project_markers(primary):
+        return primary.resolve()
+    wip = repo_root / "projects" / "working" / project_name
+    if wip.is_dir():
+        return wip.resolve()
+    flat = repo_root / "projects" / project_name
+    if flat.is_dir():
+        return flat.resolve()
+    # Public canonical exemplars live under ``projects/templates/<name>`` and
+    # must resolve by bare name as well. Without this, an output-only shadow
+    # under ``projects/active/<name>`` (or the stable error-path fallback below)
+    # shadows a real exemplar source tree, so consumers such as
+    # ``infrastructure.autoresearch.build_autoresearch_plan`` silently load
+    # default config instead of the exemplar's own. Checked after the
+    # hot-seat/WIP/flat trees so an actually-promoted project still wins.
+    templated = repo_root / "projects" / "templates" / project_name
+    if templated.is_dir() and has_project_markers(templated):
+        return templated.resolve()
+    if primary.is_dir():
+        return primary.resolve()
+    return primary
+
+
+__all__ = ["NON_RENDERED_SUBDIRS", "resolve_project_root"]

--- a/infrastructure/core/runtime/_directories.py
+++ b/infrastructure/core/runtime/_directories.py
@@ -7,7 +7,7 @@ the source code directory structure.
 from pathlib import Path
 
 from infrastructure.core.logging.utils import get_logger, log_success
-from infrastructure.project.discovery import resolve_project_root
+from infrastructure.core.project_paths import resolve_project_root
 
 logger = get_logger(__name__)
 

--- a/infrastructure/core/runtime/setup_checks.py
+++ b/infrastructure/core/runtime/setup_checks.py
@@ -52,7 +52,8 @@ def sync_workspace_dependencies(repo_root: Path) -> bool:
 
 
 def validate_project_discovery(repo_root: Path, project_name: str) -> bool:
-    from infrastructure.project.discovery import discover_projects, resolve_project_root
+    from infrastructure.core.project_paths import resolve_project_root
+    from infrastructure.project.discovery import discover_projects
     from infrastructure.project.validation import validate_project_structure
 
     logger.info("Discovering available projects...")
@@ -92,7 +93,7 @@ def validate_project_discovery(repo_root: Path, project_name: str) -> bool:
 
 
 def run_optional_setup_hook(repo_root: Path, project_name: str) -> bool:
-    from infrastructure.project.discovery import resolve_project_root
+    from infrastructure.core.project_paths import resolve_project_root
     from infrastructure.project.setup_hook import run_project_setup_hook
 
     project_dir = resolve_project_root(repo_root, project_name)

--- a/infrastructure/core/script_discovery.py
+++ b/infrastructure/core/script_discovery.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from infrastructure.core.exceptions import PipelineError
 from infrastructure.core.logging.utils import get_logger, log_success
-from infrastructure.project.discovery import resolve_project_root
+from infrastructure.core.project_paths import resolve_project_root
 
 logger = get_logger(__name__)
 

--- a/infrastructure/core/test_runner.py
+++ b/infrastructure/core/test_runner.py
@@ -56,7 +56,8 @@ from infrastructure.core.pytest_orchestration import (
 )
 from infrastructure.core.pytest_marker_exprs import build_pytest_marker_expression
 from infrastructure.core.runtime._python_env import get_python_command
-from infrastructure.project.discovery import discover_projects, resolve_project_root
+from infrastructure.core.project_paths import resolve_project_root
+from infrastructure.project.discovery import discover_projects
 from infrastructure.project.metadata import get_project_metadata
 
 logger = get_logger(__name__)

--- a/infrastructure/doctor/cli.py
+++ b/infrastructure/doctor/cli.py
@@ -315,7 +315,6 @@ def cmd_capabilities(args: argparse.Namespace) -> int:
             "warn": 1,
             "error": 2,
             "critical": 3,
-            "regression": 4,
             "usage": 64,
         },
     }
@@ -354,7 +353,6 @@ EXIT CODES
   1  warnings present
   2  one or more errors
   3  critical findings present
-  4  regression introduced by a fix (rare)
   64 usage error (BSD EX_USAGE)
 
 CONTRACT

--- a/infrastructure/doctor/reporter.py
+++ b/infrastructure/doctor/reporter.py
@@ -43,6 +43,9 @@ EXIT_HEALTHY = 0
 EXIT_WARN = 1
 EXIT_ERROR = 2
 EXIT_CRITICAL = 3
+# Reserved for future regression detection in ``cmd_fix``; not yet emitted by
+# ``compute_exit_code``, so it is deliberately absent from the agent-facing
+# exit-code contract (cli.py capabilities / robot-docs) until wired.
 EXIT_REGRESSION = 4
 EXIT_USAGE = 64
 

--- a/infrastructure/llm/cli/__main__.py
+++ b/infrastructure/llm/cli/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m infrastructure.llm.cli`` entry point."""
+
+from infrastructure.llm.cli.main import main
+
+if __name__ == "__main__":
+    main()

--- a/infrastructure/orchestration/secure_run.py
+++ b/infrastructure/orchestration/secure_run.py
@@ -12,7 +12,7 @@ Public API:
   project. Used standalone via ``--steganography-only``.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -36,7 +36,6 @@ class SecureRunOptions:
     skip_infra: bool = False
     core_only: bool = False
     resume: bool = False
-    extra_args: list[str] = field(default_factory=list)
 
 
 def _load_steganography():  # pragma: no cover - import indirection

--- a/infrastructure/project/discovery.py
+++ b/infrastructure/project/discovery.py
@@ -14,7 +14,7 @@ from infrastructure.core.logging.utils import get_logger
 # (core.project_paths). Re-exported here so existing
 # ``from infrastructure.project.discovery import resolve_project_root`` callers
 # keep working, without the foundation having to import upward into project.
-from infrastructure.core.project_paths import (  # noqa: F401  (re-export)
+from infrastructure.core.project_paths import (
     NON_RENDERED_SUBDIRS,
     resolve_project_root,
 )
@@ -22,6 +22,16 @@ from infrastructure.project.project_info import ProjectInfo, build_project_info
 from infrastructure.project.validation import validate_project_structure
 
 logger = get_logger(__name__)
+
+#: Public API of this module. ``resolve_project_root`` and ``NON_RENDERED_SUBDIRS``
+#: are re-exported from :mod:`infrastructure.core.project_paths` (declared here so
+#: the re-export is explicit per docs/rules/api_design.md).
+__all__ = [
+    "NON_RENDERED_SUBDIRS",
+    "discover_projects",
+    "get_default_project",
+    "resolve_project_root",
+]
 
 
 def discover_projects(

--- a/infrastructure/project/discovery.py
+++ b/infrastructure/project/discovery.py
@@ -9,17 +9,19 @@ sibling sub-modules (``metadata``, ``validation``, ``project_info``) or from the
 from pathlib import Path
 
 from infrastructure.core.logging.utils import get_logger
+
+# resolve_project_root and NON_RENDERED_SUBDIRS now live in the foundation layer
+# (core.project_paths). Re-exported here so existing
+# ``from infrastructure.project.discovery import resolve_project_root`` callers
+# keep working, without the foundation having to import upward into project.
+from infrastructure.core.project_paths import (  # noqa: F401  (re-export)
+    NON_RENDERED_SUBDIRS,
+    resolve_project_root,
+)
 from infrastructure.project.project_info import ProjectInfo, build_project_info
 from infrastructure.project.validation import validate_project_structure
 
 logger = get_logger(__name__)
-
-#: Typed subfolders under ``projects/`` that hold non-rendered lifecycle mirrors.
-#: Their nested projects are deliberately excluded from discovery so they never
-#: enter the render set. Only ``templates/`` (public exemplars) and ``active/``
-#: (the hot seat) are discovered. Keep in sync with
-#: :data:`infrastructure.project.linking.LIFECYCLE_LINK_DIRS`.
-NON_RENDERED_SUBDIRS: frozenset[str] = frozenset({"working", "published", "archive", "other"})
 
 
 def discover_projects(
@@ -117,66 +119,6 @@ def discover_projects(
                 logger.debug(f"Skipping {child_dir.name}: {message}")
 
     return projects
-
-
-def resolve_project_root(repo_root: Path | str, project_name: str) -> Path:
-    """Return the directory for *project_name*, preferring the hot seat over WIP trees.
-
-    Use this when a tool should find a work-in-progress tree (for example COGANT) that has not
-    been promoted to ``projects/active/`` yet. If ``projects/active/<project_name>`` exists and
-    looks like a project source tree, that path wins; otherwise
-    ``projects/working/<project_name>`` is used when present, then a flat
-    standalone ``projects/<project_name>`` tree. A skeletal generated-output
-    directory does not shadow an actual WIP source tree.
-
-    If none of those exist, returns ``projects/active/<project_name>`` so callers get a
-    stable path for error messages.
-
-    Args:
-        repo_root: Repository root (directory containing ``infrastructure/``).
-        project_name: Final path segment (e.g. ``\"cogant\"``).
-
-    Returns:
-        Absolute resolved path to the project directory.
-    """
-    if isinstance(repo_root, str):
-        repo_root = Path(repo_root)
-
-    def has_project_markers(path: Path) -> bool:
-        return any((path / marker).exists() for marker in ("src", "tests", "scripts", "manuscript"))
-
-    # A name that already carries a typed-subfolder prefix (e.g. ``active/demo``,
-    # ``working/draft``, ``templates/template_code_project``) is resolved directly
-    # under ``projects/`` without re-prepending the hot-seat prefix.
-    head = project_name.replace("\\", "/").split("/", 1)[0]
-    if head in (NON_RENDERED_SUBDIRS | {"active", "templates"}):
-        qualified = repo_root / "projects" / project_name
-        if qualified.is_dir():
-            return qualified.resolve()
-        return qualified
-
-    primary = repo_root / "projects" / "active" / project_name
-    if primary.is_dir() and has_project_markers(primary):
-        return primary.resolve()
-    wip = repo_root / "projects" / "working" / project_name
-    if wip.is_dir():
-        return wip.resolve()
-    flat = repo_root / "projects" / project_name
-    if flat.is_dir():
-        return flat.resolve()
-    # Public canonical exemplars live under ``projects/templates/<name>`` and
-    # must resolve by bare name as well. Without this, an output-only shadow
-    # under ``projects/active/<name>`` (or the stable error-path fallback below)
-    # shadows a real exemplar source tree, so consumers such as
-    # ``infrastructure.autoresearch.build_autoresearch_plan`` silently load
-    # default config instead of the exemplar's own. Checked after the
-    # hot-seat/WIP/flat trees so an actually-promoted project still wins.
-    templated = repo_root / "projects" / "templates" / project_name
-    if templated.is_dir() and has_project_markers(templated):
-        return templated.resolve()
-    if primary.is_dir():
-        return primary.resolve()
-    return primary
 
 
 def _discover_nested_projects(program_dir: Path, program_name: str) -> list[ProjectInfo]:

--- a/infrastructure/prose/markdown.py
+++ b/infrastructure/prose/markdown.py
@@ -16,7 +16,6 @@ _IMAGE_RE = re.compile(r"!\[([^\]]*)\]\([^\)]+\)")
 _MARKDOWN_HEADER_RE = re.compile(r"^#+\s*", re.MULTILINE)
 _PANDOC_ATTR_RE = re.compile(r"\s*\{#[^}]+\}")
 _PANDOC_CARET_ATTR_RE = re.compile(r"\s*\{\^[^}]+\}")
-_EMPHASIS_RE = re.compile(r"\*\*([^*]+)\*\*|\*([^*]+)\*|__([^_]+)__|_([^_]+)_")
 _CITATION_RE = re.compile(r"\[@([^\]]+)\]")
 _HRULE_RE = re.compile(r"^\s*---+\s*$", re.MULTILINE)
 _PANDOC_RAW_LATEX_ATTR_RE = re.compile(r"\{=latex\}")
@@ -85,18 +84,6 @@ def strip_emphasis_asterisk(text: str) -> str:
         return match.group(0)
 
     return re.sub(r"\*\*([^*]+)\*\*|\*([^*]+)\*", _replace, text)
-
-
-def strip_emphasis(text: str) -> str:
-    """Remove bold/italic markers, keeping inner text."""
-
-    def _replace(match: re.Match[str]) -> str:
-        for group in match.groups():
-            if group is not None:
-                return group
-        return match.group(0)
-
-    return _EMPHASIS_RE.sub(_replace, text)
 
 
 def strip_citations(text: str) -> str:

--- a/infrastructure/reference/citation/__main__.py
+++ b/infrastructure/reference/citation/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m infrastructure.reference.citation`` entry point."""
+
+from infrastructure.reference.citation.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/reference/citation/bibtex_parser.py
+++ b/infrastructure/reference/citation/bibtex_parser.py
@@ -20,16 +20,15 @@ from collections import OrderedDict
 from pathlib import Path
 
 from infrastructure.reference.citation.escape import unescape_latex
-from infrastructure.reference.citation.models import BibDatabase, BibEntry
+from infrastructure.reference.citation.models import (
+    VERBATIM_FIELDS as _VERBATIM_FIELDS,
+    BibDatabase,
+    BibEntry,
+)
 
 
 class BibParseError(ValueError):
     """Raised when the parser encounters a malformed BibTeX construct."""
-
-
-_VERBATIM_FIELDS: frozenset[str] = frozenset(
-    {"year", "volume", "number", "month", "edition", "isbn", "issn", "doi", "url"}
-)
 
 
 class _Reader:

--- a/infrastructure/reference/citation/bibtex_writer.py
+++ b/infrastructure/reference/citation/bibtex_writer.py
@@ -22,15 +22,13 @@ from pathlib import Path
 from typing import Iterable
 
 from infrastructure.reference.citation.escape import escape_latex
-from infrastructure.reference.citation.models import BibDatabase, BibEntry
+from infrastructure.reference.citation.models import (
+    VERBATIM_FIELDS as _VERBATIM_FIELDS,
+    BibDatabase,
+    BibEntry,
+)
 
 _INDENT = "  "
-
-# Fields whose values are numeric / symbolic and should *not* be LaTeX-escaped.
-# (Matches the convention in the exemplar references.bib.)
-_VERBATIM_FIELDS: frozenset[str] = frozenset(
-    {"year", "volume", "number", "month", "edition", "isbn", "issn", "doi", "url"}
-)
 
 # Author-like fields are split on " and " for normalisation but otherwise
 # escaped like normal text.

--- a/infrastructure/reference/citation/models.py
+++ b/infrastructure/reference/citation/models.py
@@ -50,6 +50,14 @@ CANONICAL_ENTRY_TYPES: frozenset[str] = frozenset(
     }
 )
 
+# Fields whose values are numeric / symbolic and must NOT be LaTeX-escaped on
+# write nor LaTeX-unescaped on read. This is round-trip-critical shared
+# vocabulary: the parser skips ``unescape_latex`` for these and the writer skips
+# ``escape_latex`` for them. Defined once here so the two cannot drift.
+VERBATIM_FIELDS: frozenset[str] = frozenset(
+    {"year", "volume", "number", "month", "edition", "isbn", "issn", "doi", "url"}
+)
+
 
 @dataclass
 class BibEntry:

--- a/infrastructure/rendering/pipeline.py
+++ b/infrastructure/rendering/pipeline.py
@@ -32,7 +32,6 @@ from infrastructure.rendering._pipeline_summary import (  # noqa: F401
     generate_rendering_summary,
     log_rendering_summary,
     verify_pdf_outputs,
-    _check_citations_used,
 )
 
 logger = get_logger(__name__)

--- a/infrastructure/scientific/stability.py
+++ b/infrastructure/scientific/stability.py
@@ -30,8 +30,13 @@ class StabilityTest:
     recommendations: list[str]
 
 
-def _score_result(result: Any) -> tuple[str, float]:
-    """Return (behavior_label, stability_score) for a numeric result."""
+def _score_result(result: Any, tolerance: float) -> tuple[str, float]:
+    """Return (behavior_label, stability_score) for a numeric result.
+
+    ``tolerance`` flags near-underflow instability: a finite, non-zero result
+    whose magnitude falls below ``tolerance`` (e.g. the residue of catastrophic
+    cancellation) is treated as numerically suspect rather than fully stable.
+    """
     has_nan = np.isnan(result).any() if hasattr(result, "any") else np.isnan(result)
     has_inf = np.isinf(result).any() if hasattr(result, "any") else np.isinf(result)
     if has_nan:
@@ -40,6 +45,10 @@ def _score_result(result: Any) -> tuple[str, float]:
         return "Infinite values detected", 0.0
     if np.abs(result) > 1e10:
         return "Extremely large values", 0.3
+    magnitude = np.abs(result)
+    underflow = (magnitude > 0) & (magnitude < tolerance)
+    if underflow.any() if hasattr(underflow, "any") else underflow:
+        return "Near-underflow values", 0.3
     return "Numerically stable", 1.0
 
 
@@ -61,7 +70,7 @@ def check_numerical_stability(
     for test_input in test_inputs:
         try:
             result = func(test_input)
-            behavior, score = _score_result(result)
+            behavior, score = _score_result(result, tolerance)
             results.append((test_input, result, behavior, score))
 
         except Exception as e:  # noqa: BLE001 — any function failure is a stability event

--- a/infrastructure/search/exa/AGENTS.md
+++ b/infrastructure/search/exa/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS — `infrastructure.search.exa`
+
+Exa REST client. One subpackage per search interface (`search/`, `contents/`,
+`answer/`, `find_similar/`); shared core (`client.py`, `config.py`, `models.py`,
+`http.py`, `errors.py`) at the package root.
+
+## Invariants (do not break)
+
+- **No import-time side effects.** Importing the package must not read
+  `EXA_API_KEY` or hit the network. Env is read only in `ExaConfig.from_env`.
+- **No external SDK.** Transport is stdlib `urllib` via `UrllibExaHttpClient`,
+  injectable for tests. Do not add an `exa_py` runtime dependency.
+- **No mocks in tests.** Use `pytest-httpserver` and a `base_url` override
+  (`tests/infra_tests/search/test_exa.py`).
+- **camelCase on the wire.** Build payloads with `models.prune` + the per-field
+  camelCase keys. Content keys (`highlights`/`text`/`summary`) nest under
+  `contents` for `/search` and `/findSimilar`, but are **top-level** for
+  `/contents`.
+- **Errors are `ExaError`** carrying `.status`/`.body` for non-2xx.
+
+## Adding a new Exa endpoint
+
+1. New subfolder `exa/<endpoint>/` with `interface.py` (an `Exa<Name>Interface`
+   taking the client) + `__init__.py` exporting it + a one-line `README.md`.
+2. Add a lazy `@cached_property` + convenience pass-through on `ExaClient`.
+3. Add response model to `models.py` (a `from_dict` classmethod).
+4. Add a `pytest-httpserver` test asserting the wire payload and parsed result.
+5. Re-export from `exa/__init__.py`.
+
+## Source of truth
+
+<https://docs.exa.ai/reference/search-api-guide-for-coding-agents> — if behaviour
+contradicts this code, fetch it and reconcile; report staleness.

--- a/infrastructure/search/exa/CAPABILITIES.md
+++ b/infrastructure/search/exa/CAPABILITIES.md
@@ -1,0 +1,221 @@
+# `infrastructure.search.exa` — Methods, Return Shapes & What You Can Learn
+
+A practical reference for every method on `ExaClient`: what it does, what it
+returns, and what intelligence you can extract (entities, citations, full text,
+relevance scores, cost). Every row below was **confirmed against the live Exa
+API on 2026-06-02** with a real key — not just read from the client code.
+
+> **Source of truth for the wire API:**
+> <https://docs.exa.ai/reference/search-api-guide-for-coding-agents>
+> This file documents the *Python client*; if it drifts from real behaviour,
+> fetch that URL and re-run the probes in this doc.
+
+## Setup
+
+```python
+from infrastructure.search.exa import ExaClient
+client = ExaClient.from_env()   # reads EXA_API_KEY from the environment
+```
+
+`from_env()` reads `os.environ` only — it does **not** auto-load `.env`. Either
+`set -a; source .env; set +a` first, or go through anything that calls
+`load_dotenv()` (e.g. `infrastructure.core.credentials.CredentialManager`).
+
+## At a glance
+
+| Method | Endpoint | Input | Returns | Primary use | Live status | Typical cost |
+|--------|----------|-------|---------|-------------|-------------|--------------|
+| `client.search(query, …)` | `POST /search` | free-text query | `SearchResponse` | Find pages; optionally synthesise grounded JSON | ✅ confirmed | ~$0.005–0.012 |
+| `client.contents(urls, …)` | `POST /contents` | known URLs / result `id`s | `ContentsResponse` | Extract clean parsed text/highlights for URLs you already have | ✅ confirmed | ~$0.001 |
+| `client.answer(query, …)` | `POST /answer` | question | `AnswerResponse` | One grounded answer + citations (question-first UIs) | ✅ confirmed | ~$0.005 |
+| `client.find_similar(url, …)` | `POST /findSimilar` | seed URL | `SearchResponse` | Semantically similar pages to a seed document | ✅ confirmed | ~$0.007 |
+
+> **Fix landed 2026-06-02:** `find_similar` previously posted to `/find-similar`
+> and returned **HTTP 404** against the live API. The correct path is camelCase
+> `/findSimilar`. The no-mocks httpserver test had registered the *same wrong
+> path*, so it passed while the real endpoint was broken — the test encoded the
+> bug. Both code and test now use `/findSimilar`, re-verified live.
+
+---
+
+## The universal record: `ExaResult`
+
+Every endpoint normalises results into the same `ExaResult` dataclass, so
+`/search`, `/contents`, `/findSimilar` results and `/answer` citations are all
+consumed uniformly. Fields:
+
+| Field | Type | Populated when | What you learn |
+|-------|------|----------------|----------------|
+| `id` | `str` | always | Stable Exa doc id — re-fetch via `/contents` (falls back to URL) |
+| `url` | `str \| None` | always | Canonical landing page |
+| `title` | `str \| None` | usually | Page/document title |
+| `score` | `float \| None` | `/findSimilar` (and relevance-ranked search) | Semantic similarity 0–1; **`None` for plain neural `/search`** |
+| `published_date` | `str \| None` | when known | Publication date (often `None` for academic PDFs) |
+| `author` | `str \| None` | when known | Author(s) — e.g. `"Ryan Smith, Karl J. Friston, …"` |
+| `text` | `str \| None` | `text=True` | Full parsed page text (e.g. 44 039 chars for a Wikipedia article) |
+| `highlights` | `list[str]` | default / `highlights=True` | Query-relevant excerpts (token-efficient) |
+| `highlight_scores` | `list[float]` | with highlights | Per-highlight relevance |
+| `summary` | `str \| None` | `summary=True` | LLM-written summary of the page |
+| `image` / `favicon` | `str \| None` | when present | Lead image / site favicon URLs |
+| `extras` | `dict` | varies | Endpoint extras (e.g. subpages) |
+| `raw` | `dict` | always | The untouched JSON object — anything not modelled is here |
+
+`SearchResponse` / `ContentsResponse` / `AnswerResponse` also carry
+`request_id`, `cost_dollars` (parsed from `costDollars.total`), and `raw`.
+
+---
+
+## 1. `search()` — neural/keyword retrieval + grounded synthesis
+
+`POST /search`. Two modes from one method.
+
+### 1a. Raw retrieval (default)
+
+```python
+r = client.search("active inference free energy principle tutorial", num_results=3)
+for x in r.results:
+    print(x.title, x.url, x.author, x.highlights[:1])
+print(r.cost_dollars)   # e.g. 0.007
+```
+
+Defaults to `highlights=True` (the token-efficient mode). **What you learn:**
+ranked pages with title/url/id/author + query-relevant highlight excerpts.
+Note plain neural search returns `score=None` and often `published_date=None`.
+
+Key params: `type` (`auto`·`fast`·`instant`·`deep-lite`·`deep`·`deep-reasoning`),
+`num_results`, `category`, `include_domains`/`exclude_domains`,
+`start_published_date`/`end_published_date`, `user_location`, `moderation`.
+Content knobs: `highlights`, `text`, `summary`, `max_age_hours` (freshness /
+livecrawl), `subpages`.
+
+> Guardrail enforced client-side: `category="company"|"people"` rejects
+> `exclude_domains` and date filters (Exa returns HTTP 400) — caught before the
+> request with a clear `ExaError`.
+
+### 1b. Structured output / **entity extraction** (`output_schema`)
+
+Pass a JSON Schema and Exa synthesises grounded JSON with **field-level
+citations**. This is the path for "pull entities + where each fact came from."
+
+```python
+schema = {
+  "type": "object", "required": ["researchers"],
+  "properties": {"researchers": {"type": "array", "items": {
+    "type": "object", "required": ["name"],
+    "properties": {"name": {"type": "string"}, "affiliation": {"type": "string"}}}}},
+}
+r = client.search("key researchers in active inference", type="deep",
+                  output_schema=schema,
+                  system_prompt="Prefer primary sources; dedupe people.")
+print(r.output.content)      # → {"researchers": [{"name": "Karl J. Friston", "affiliation": "…UCL…"}, …]}
+for g in r.output.grounding: # field-level provenance
+    print(g.field, g.confidence, [c["url"] for c in g.citations])
+```
+
+**Live result (2026-06-02):** extracted Karl J. Friston, Thomas Parr, Giovanni
+Pezzulo, Thomas FitzGerald with affiliations; grounding e.g.
+`field=researchers[0].name confidence=high citations=['https://www.fil.ion.ucl.ac.uk/~karl/', …]`.
+Cost $0.012.
+
+- `r.output.content` — your schema's shape (dict, or a string for `{"type":"text"}`).
+- `r.output.grounding` — list of `Grounding(field, citations, confidence)`;
+  `confidence ∈ {high, medium, low}`, `citations` are `{url, title}` dicts.
+- Schema limits: nesting depth ≤ 2, ≤ 10 total properties. Do **not** add
+  citation/confidence fields yourself — grounding is returned automatically.
+- `output_schema` works on **every** `type`; `deep`/`deep-reasoning` give
+  higher-quality synthesis at higher latency/cost.
+
+**What you can learn here:** named entities (people, companies, products),
+structured attributes per entity, and a per-field citation trail with
+confidence — i.e. extraction *and* its evidence in one call.
+
+---
+
+## 2. `contents()` — clean parsed content for URLs you already have
+
+`POST /contents`. For URLs from a database, RSS, user input, or prior result
+`id`s — and to refresh stale content via `max_age_hours`.
+
+```python
+r = client.contents(["https://en.wikipedia.org/wiki/Free_energy_principle"], text=True)
+x = r.results[0]
+print(x.title, len(x.text))   # "Free energy principle - Wikipedia", 44039
+```
+
+**Live result:** 44 039 chars of parsed text, cost $0.001 (cheapest endpoint).
+Params: `highlights` / `text` / `summary` (default highlights), `max_age_hours`,
+`livecrawl_timeout`, `subpages`. **What you learn:** full body text (RAG-ready),
+highlights, or an LLM summary for arbitrary URLs without a search step.
+
+> Content keys are **top-level** on `/contents` but **nested under `contents`**
+> on `/search` and `/findSimilar`. The client handles this per-interface, so you
+> never hit the documented mistake.
+
+---
+
+## 3. `answer()` — one grounded answer + citations
+
+`POST /answer`. Best for question-first UIs where you want a synthesised answer
+and don't need to inspect raw results.
+
+```python
+r = client.answer("What is the free energy principle in one sentence?")
+print(r.answer)                                  # synthesised, with [1][2][3] markers
+for c in r.citations: print(c.title, "::", c.url)
+```
+
+**Live result:** a one-sentence grounded answer plus 4 citations including the
+MIT *Open Encyclopedia of Cognitive Science*, Friston's *TICS* "rough guide",
+and the *Unified brain theory* paper. Cost $0.005. Params: `text=True` (include
+full source text on each citation), `system_prompt`, `output_schema` (structured
+answer). **What you learn:** a cited natural-language answer + its full source
+list as `ExaResult` citations.
+
+---
+
+## 4. `find_similar()` — semantically similar pages for a seed URL
+
+`POST /findSimilar`. Same `SearchResponse` shape as `/search`, but the query is
+a URL instead of free text.
+
+```python
+r = client.find_similar("https://arxiv.org/abs/1706.03762",
+                        num_results=3, exclude_source_domain=True)
+for x in r.results: print(x.score, x.title, x.url)
+```
+
+**Live result (2026-06-02, post-fix):** for the "Attention Is All You Need"
+arXiv URL → NeurIPS/NIPS proceedings copies and a related OpenReview PDF, with
+real similarity **scores** (0.927, 0.895, 0.882). Cost $0.007. Params:
+`num_results`, `include_domains`/`exclude_domains`, date filters,
+`exclude_source_domain` (drop pages from the seed's own domain), content knobs.
+**What you learn:** a ranked neighbourhood of related documents *with* similarity
+scores — the one endpoint that reliably populates `ExaResult.score`.
+
+---
+
+## Cross-cutting: what intelligence is available
+
+| You want… | Use | Field(s) |
+|-----------|-----|----------|
+| Ranked relevant URLs | `search` | `results[].url/title/id` |
+| Query-relevant excerpts (cheap) | any, default | `results[].highlights` |
+| Full page text (RAG) | `search`/`contents` `text=True` | `results[].text` |
+| **Named entities + attributes** | `search(output_schema=…)` | `output.content` |
+| **Per-fact citations + confidence** | `search(output_schema=…)` | `output.grounding[].{citations,confidence}` |
+| A cited natural-language answer | `answer` | `answer` + `citations[]` |
+| Author / publication date | any | `results[].author` / `published_date` (often `None` for PDFs) |
+| Similarity scores | `find_similar` | `results[].score` |
+| Spend per call | all | `cost_dollars` (`raw["costDollars"]` for the breakdown) |
+| Anything unmodelled | all | `results[].raw`, `response.raw` |
+
+## Errors & reproducing this doc
+
+All failures raise `ExaError` (with `.status` / `.body` on non-2xx). Transient
+TLS handshake/read timeouts are wrapped as `ExaError` too — wrap live calls in a
+short retry loop (the probes used to confirm this doc retried 4–6×).
+
+To re-confirm against the live API: `set -a; source .env; set +a` then exercise
+each method as shown above. Offline/CI verification is the no-mocks suite:
+`uv run pytest tests/infra_tests/search/test_exa.py -q` (20 tests, pytest-httpserver,
+no network).

--- a/infrastructure/search/exa/README.md
+++ b/infrastructure/search/exa/README.md
@@ -1,0 +1,92 @@
+# `infrastructure.search.exa`
+
+Self-contained client for the [Exa](https://exa.ai) search API — a second search
+interface under `infrastructure/search`, sibling to
+[`literature/`](../literature/README.md). Where `literature` discovers academic
+papers, `exa` is general web search, content extraction, and grounded answers.
+
+> **Canonical API reference (source of truth):**
+> <https://docs.exa.ai/reference/search-api-guide-for-coding-agents>
+> If anything here drifts from real API behaviour, fetch that URL and report it.
+
+## Layout — one subpackage per Exa search interface
+
+```
+exa/
+├── config.py            ExaConfig (EXA_API_KEY, host, defaults)
+├── errors.py            ExaError
+├── http.py              ExaHttpClient protocol + UrllibExaHttpClient + ExaResponse
+├── models.py            ExaResult, SearchResponse, ContentsResponse, AnswerResponse, …
+├── client.py            ExaClient — the facade tying the interfaces together
+├── cli.py / __main__.py python -m infrastructure.search.exa …
+├── search/              POST /search        — neural/keyword + structured output
+├── contents/            POST /contents      — parsed content for known URLs
+├── answer/              POST /answer        — grounded answer + citations
+└── find_similar/        POST /findSimilar  — similar pages for a seed URL
+```
+
+## Setup
+
+```bash
+export EXA_API_KEY="YOUR_API_KEY"   # keys: https://dashboard.exa.ai/api-keys
+```
+
+The package never reads the environment at import time — construction is explicit
+via `ExaClient.from_env()` (or `ExaConfig(api_key=...)` for tests).
+
+## Quick start
+
+```python
+from infrastructure.search.exa import ExaClient
+
+client = ExaClient.from_env()
+
+# Raw retrieval (token-efficient highlights — the default)
+resp = client.search("Next.js route handler authentication example", num_results=10)
+for r in resp.results:
+    print(r.title, r.url, r.highlights)
+
+# Grounded structured output (synthesised JSON + field-level citations)
+resp = client.search(
+    "articles about GPUs",
+    output_schema={"type": "object", "properties": {"summary": {"type": "string"}}},
+    system_prompt="Prefer official sources and collapse duplicate reporting.",
+)
+print(resp.output.content, resp.output.grounding)
+
+# Content for URLs you already have
+client.contents(["https://example.com/post"], text=True)
+
+# Grounded answer for a question-first UI
+client.answer("what is retrieval-augmented generation?")
+
+# Similar pages for a seed URL
+client.find_similar("https://arxiv.org/abs/1706.03762", num_results=5)
+```
+
+## CLI
+
+```bash
+python -m infrastructure.search.exa search "vector database benchmarks" --num-results 5
+python -m infrastructure.search.exa contents https://example.com/post --text
+python -m infrastructure.search.exa answer "what is RAG?"
+python -m infrastructure.search.exa find-similar https://arxiv.org/abs/1706.03762
+```
+
+## Search types
+
+`auto` (default, balanced) · `fast` · `instant` · `deep-lite` · `deep` ·
+`deep-reasoning`. `output_schema` works on **every** type; deep variants give
+higher-quality synthesis. See the guide's Search Type Reference for latencies.
+
+## Design notes
+
+- **camelCase on the wire, snake_case in Python.** `build_contents_payload`
+  is the single place the conventions meet; `None` arguments are pruned.
+- **Content keys nest under `contents` on `/search`** but are top-level on
+  `/contents` — handled per interface so callers never hit the documented
+  mistake.
+- **Fail-fast guards** mirror documented `400`s: `category` `company`/`people`
+  reject `exclude_domains` and date filters (caught before the request).
+- **No external SDK / no import-time network.** Pure-stdlib transport keeps the
+  core pipeline offline-reproducible; tests use `pytest-httpserver`, no mocks.

--- a/infrastructure/search/exa/__init__.py
+++ b/infrastructure/search/exa/__init__.py
@@ -1,0 +1,76 @@
+"""Exa search interface — neural/keyword web search via the Exa REST API.
+
+A second search interface under :mod:`infrastructure.search`, sibling to
+:mod:`infrastructure.search.literature`. Where ``literature`` discovers academic
+papers across arXiv/Crossref/local corpora, ``exa`` is a general web search,
+content-extraction, and grounded-answer interface backed by https://exa.ai.
+
+Each Exa endpoint lives in its own subpackage:
+
+* :mod:`infrastructure.search.exa.search` — ``POST /search`` (neural/keyword + structured output)
+* :mod:`infrastructure.search.exa.contents` — ``POST /contents`` (parsed content for known URLs)
+* :mod:`infrastructure.search.exa.answer` — ``POST /answer`` (grounded answer + citations)
+* :mod:`infrastructure.search.exa.find_similar` — ``POST /findSimilar`` (similar pages for a seed URL)
+
+The shared core (:class:`ExaClient`, :class:`ExaConfig`, models, transport) sits
+at the package root. Construction never reads the environment, so importing this
+package is side-effect free; use :meth:`ExaClient.from_env` to pull ``EXA_API_KEY``.
+
+Canonical API reference (source of truth):
+https://docs.exa.ai/reference/search-api-guide-for-coding-agents
+
+Quick start::
+
+    from infrastructure.search.exa import ExaClient
+
+    client = ExaClient.from_env()
+    resp = client.search("Next.js route handler authentication example", num_results=10)
+    for result in resp.results:
+        print(result.title, result.url)
+"""
+
+from infrastructure.search.exa.answer import ExaAnswerInterface
+from infrastructure.search.exa.client import ExaClient
+from infrastructure.search.exa.config import (
+    API_KEY_ENV,
+    DEFAULT_BASE_URL,
+    DEFAULT_SEARCH_TYPE,
+    VALID_SEARCH_TYPES,
+    ExaConfig,
+)
+from infrastructure.search.exa.contents import ExaContentsInterface
+from infrastructure.search.exa.errors import ExaError
+from infrastructure.search.exa.find_similar import ExaFindSimilarInterface
+from infrastructure.search.exa.http import ExaHttpClient, ExaResponse, UrllibExaHttpClient
+from infrastructure.search.exa.models import (
+    AnswerResponse,
+    ContentsResponse,
+    ExaResult,
+    Grounding,
+    SearchOutput,
+    SearchResponse,
+)
+from infrastructure.search.exa.search import ExaSearchInterface
+
+__all__ = [
+    "API_KEY_ENV",
+    "DEFAULT_BASE_URL",
+    "DEFAULT_SEARCH_TYPE",
+    "VALID_SEARCH_TYPES",
+    "AnswerResponse",
+    "ContentsResponse",
+    "ExaAnswerInterface",
+    "ExaClient",
+    "ExaConfig",
+    "ExaContentsInterface",
+    "ExaError",
+    "ExaFindSimilarInterface",
+    "ExaHttpClient",
+    "ExaResponse",
+    "ExaResult",
+    "ExaSearchInterface",
+    "Grounding",
+    "SearchOutput",
+    "SearchResponse",
+    "UrllibExaHttpClient",
+]

--- a/infrastructure/search/exa/__main__.py
+++ b/infrastructure/search/exa/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m infrastructure.search.exa`` entry point."""
+
+from infrastructure.search.exa.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/search/exa/answer/AGENTS.md
+++ b/infrastructure/search/exa/answer/AGENTS.md
@@ -1,0 +1,17 @@
+# `exa/answer` package (technical)
+
+`ExaAnswerInterface` wraps `POST /answer` (`interface.py`). Returns
+`AnswerResponse` (a synthesised `answer` plus `citations` as normalised
+`ExaResult` records). Best for question-first UIs.
+
+- Empty query raises `ExaError`.
+- `text=True` asks Exa to include full source text on each citation.
+- `system_prompt=` / `output_schema=` supported for source steering / structured
+  answers. For new structured-search flows that need both retrieval control and
+  grounded output, prefer `/search` + `output_schema` instead.
+
+## Tests
+
+```bash
+uv run pytest tests/infra_tests/search/test_exa.py -q   # pytest-httpserver, no mocks
+```

--- a/infrastructure/search/exa/answer/README.md
+++ b/infrastructure/search/exa/answer/README.md
@@ -1,0 +1,13 @@
+# `exa/answer` — `POST /answer`
+
+A grounded answer with citations, for question-first UIs.
+`ExaAnswerInterface.answer(query, ...)`.
+
+- `text=True` includes full source text on each citation.
+- For structured-search flows that need retrieval control **and** grounded
+  output, prefer `exa/search` + `output_schema` instead.
+
+```python
+resp = client.answer("what is retrieval-augmented generation?")
+print(resp.answer, [c.url for c in resp.citations])
+```

--- a/infrastructure/search/exa/answer/__init__.py
+++ b/infrastructure/search/exa/answer/__init__.py
@@ -1,0 +1,5 @@
+"""Exa ``/answer`` interface package."""
+
+from infrastructure.search.exa.answer.interface import ExaAnswerInterface
+
+__all__ = ["ExaAnswerInterface"]

--- a/infrastructure/search/exa/answer/interface.py
+++ b/infrastructure/search/exa/answer/interface.py
@@ -1,0 +1,53 @@
+"""``/answer`` interface — a grounded answer with citations.
+
+Best for question-first UIs where you want a synthesised answer and do not need
+to inspect raw search results. For new structured-search flows that need both
+retrieval control and grounded output, prefer ``/search`` + ``output_schema``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping
+
+from infrastructure.search.exa.errors import ExaError
+from infrastructure.search.exa.models import AnswerResponse, prune
+
+if TYPE_CHECKING:  # pragma: no cover
+    from infrastructure.search.exa.client import ExaClient
+
+
+class ExaAnswerInterface:
+    """Wraps ``POST /answer``."""
+
+    path = "/answer"
+
+    def __init__(self, client: ExaClient) -> None:
+        self._client = client
+
+    def answer(
+        self,
+        query: str,
+        *,
+        text: bool | None = None,
+        system_prompt: str | None = None,
+        output_schema: Mapping[str, Any] | None = None,
+    ) -> AnswerResponse:
+        """Answer ``query`` from grounded sources.
+
+        ``text=True`` asks Exa to include full source text on each citation.
+        Raises :class:`ExaError` on an empty query.
+        """
+        if not query or not query.strip():
+            raise ExaError("answer query must be a non-empty string")
+        payload = prune(
+            {
+                "query": query,
+                "text": text,
+                "systemPrompt": system_prompt,
+                "outputSchema": dict(output_schema) if output_schema else None,
+            }
+        )
+        return AnswerResponse.from_dict(self._client.request(self.path, payload))
+
+
+__all__ = ["ExaAnswerInterface"]

--- a/infrastructure/search/exa/cli.py
+++ b/infrastructure/search/exa/cli.py
@@ -1,0 +1,99 @@
+"""Command-line interface for the Exa search interfaces.
+
+Thin orchestrator: parses args, constructs :class:`ExaClient` from the
+environment, delegates to an interface, and prints JSON. All logic lives in the
+interface/model modules.
+
+Examples::
+
+    python -m infrastructure.search.exa search "vector database benchmarks" --num-results 5
+    python -m infrastructure.search.exa contents https://example.com/post --text
+    python -m infrastructure.search.exa answer "what is retrieval-augmented generation?"
+    python -m infrastructure.search.exa find-similar https://arxiv.org/abs/1706.03762
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from typing import Any, Sequence
+
+from infrastructure.search.exa.client import ExaClient
+from infrastructure.search.exa.config import VALID_SEARCH_TYPES
+from infrastructure.search.exa.errors import ExaError
+
+
+def _domains(value: str | None) -> list[str] | None:
+    return [d.strip() for d in value.split(",") if d.strip()] if value else None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="exa", description="Exa search interfaces")
+    parser.add_argument("--base-url", default=None, help="override API host (testing)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_search = sub.add_parser("search", help="POST /search")
+    p_search.add_argument("query")
+    p_search.add_argument("--type", choices=sorted(VALID_SEARCH_TYPES), default=None)
+    p_search.add_argument("--num-results", type=int, default=None)
+    p_search.add_argument("--category", default=None)
+    p_search.add_argument("--include-domains", default=None, help="comma-separated")
+    p_search.add_argument("--exclude-domains", default=None, help="comma-separated")
+    p_search.add_argument("--text", action="store_true", help="request full text")
+    p_search.add_argument("--no-highlights", action="store_true", help="disable default highlights")
+
+    p_contents = sub.add_parser("contents", help="POST /contents")
+    p_contents.add_argument("urls", nargs="+")
+    p_contents.add_argument("--text", action="store_true")
+
+    p_answer = sub.add_parser("answer", help="POST /answer")
+    p_answer.add_argument("query")
+    p_answer.add_argument("--text", action="store_true")
+
+    p_similar = sub.add_parser("find-similar", help="POST /findSimilar")
+    p_similar.add_argument("url")
+    p_similar.add_argument("--num-results", type=int, default=None)
+
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    client = ExaClient.from_env(base_url=args.base_url)
+    if args.command == "search":
+        resp = client.search(
+            args.query,
+            type=args.type,
+            num_results=args.num_results,
+            category=args.category,
+            include_domains=_domains(args.include_domains),
+            exclude_domains=_domains(args.exclude_domains),
+            text=True if args.text else None,
+            highlights=None if (args.text or args.no_highlights) else True,
+        )
+        return {"results": [asdict(r) for r in resp.results], "requestId": resp.request_id}
+    if args.command == "contents":
+        resp = client.contents(args.urls, text=True if args.text else None)
+        return {"results": [asdict(r) for r in resp.results], "requestId": resp.request_id}
+    if args.command == "answer":
+        resp = client.answer(args.query, text=True if args.text else None)
+        return {"answer": resp.answer, "citations": [asdict(c) for c in resp.citations]}
+    if args.command == "find-similar":
+        resp = client.find_similar(args.url, num_results=args.num_results)
+        return {"results": [asdict(r) for r in resp.results], "requestId": resp.request_id}
+    raise ExaError(f"unknown command {args.command!r}")  # pragma: no cover - argparse guards
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        print(json.dumps(run(args), indent=2, ensure_ascii=False))
+    except ExaError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/infrastructure/search/exa/client.py
+++ b/infrastructure/search/exa/client.py
@@ -1,0 +1,103 @@
+"""``ExaClient`` — the facade that ties the per-endpoint interfaces together.
+
+Each search interface (``search``, ``contents``, ``answer``, ``find_similar``)
+lives in its own subpackage and receives the client so it can issue a request
+through one shared, audited transport path (:meth:`ExaClient.request`). Construct
+with an explicit :class:`~infrastructure.search.exa.config.ExaConfig`, or use
+:meth:`ExaClient.from_env` for the ``EXA_API_KEY`` happy path.
+"""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import Any, Mapping
+
+from infrastructure.search.exa.config import ExaConfig
+from infrastructure.search.exa.errors import ExaError
+from infrastructure.search.exa.http import ExaHttpClient, ExaResponse, UrllibExaHttpClient
+
+
+class ExaClient:
+    """Thin, dependency-injected client for the Exa REST API.
+
+    Args:
+        config: API key + host + defaults. Required.
+        http_client: Transport override. Defaults to the stdlib client; tests
+            inject a ``pytest-httpserver``-backed one via ``config.base_url``.
+    """
+
+    def __init__(self, config: ExaConfig, *, http_client: ExaHttpClient | None = None) -> None:
+        self.config = config
+        self.http: ExaHttpClient = http_client or UrllibExaHttpClient()
+
+    @classmethod
+    def from_env(cls, *, base_url: str | None = None, http_client: ExaHttpClient | None = None) -> ExaClient:
+        """Construct from ``EXA_API_KEY``; raises :class:`ExaError` if unset."""
+        return cls(ExaConfig.from_env(base_url=base_url), http_client=http_client)
+
+    def request(self, path: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        """POST ``payload`` to ``base_url + path`` and return the parsed JSON.
+
+        Raises:
+            ExaError: on non-2xx status (with ``status``/``body`` attached) or a
+                non-JSON body.
+        """
+        url = f"{self.config.base_url}/{path.lstrip('/')}"
+        resp: ExaResponse = self.http.post(
+            url,
+            json=dict(payload),
+            headers=self.config.auth_headers(),
+            timeout=self.config.timeout,
+        )
+        if not 200 <= resp.status_code < 300:
+            raise ExaError(
+                f"Exa {path} returned HTTP {resp.status_code}",
+                status=resp.status_code,
+                body=resp.text[:1000],
+            )
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise ExaError(f"Exa {path} returned a non-object JSON body", status=resp.status_code)
+        return data
+
+    # -- Per-interface facades (lazy so unused endpoints cost nothing) --------
+
+    @cached_property
+    def search_interface(self) -> Any:
+        from infrastructure.search.exa.search import ExaSearchInterface
+
+        return ExaSearchInterface(self)
+
+    @cached_property
+    def contents_interface(self) -> Any:
+        from infrastructure.search.exa.contents import ExaContentsInterface
+
+        return ExaContentsInterface(self)
+
+    @cached_property
+    def answer_interface(self) -> Any:
+        from infrastructure.search.exa.answer import ExaAnswerInterface
+
+        return ExaAnswerInterface(self)
+
+    @cached_property
+    def find_similar_interface(self) -> Any:
+        from infrastructure.search.exa.find_similar import ExaFindSimilarInterface
+
+        return ExaFindSimilarInterface(self)
+
+    # Convenience pass-throughs so callers can use ``client.search(...)`` etc.
+    def search(self, query: str, **kwargs: Any) -> Any:
+        return self.search_interface.search(query, **kwargs)
+
+    def contents(self, urls: Any, **kwargs: Any) -> Any:
+        return self.contents_interface.get(urls, **kwargs)
+
+    def answer(self, query: str, **kwargs: Any) -> Any:
+        return self.answer_interface.answer(query, **kwargs)
+
+    def find_similar(self, url: str, **kwargs: Any) -> Any:
+        return self.find_similar_interface.find_similar(url, **kwargs)
+
+
+__all__ = ["ExaClient"]

--- a/infrastructure/search/exa/config.py
+++ b/infrastructure/search/exa/config.py
@@ -1,0 +1,79 @@
+"""Configuration for the Exa search client.
+
+The only required secret is ``EXA_API_KEY``. Everything else has a documented
+default so a coding agent can construct :class:`ExaConfig` with nothing but the
+environment variable set.
+
+Canonical reference (source of truth for hosts/params/shape):
+https://docs.exa.ai/reference/search-api-guide-for-coding-agents
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from infrastructure.search.exa.errors import ExaError
+
+#: Public Exa REST host. Override per-request only for tests (httpserver).
+DEFAULT_BASE_URL = "https://api.exa.ai"
+
+#: Environment variable holding the API key.
+API_KEY_ENV = "EXA_API_KEY"
+
+#: Balanced default search type — see the Search Type Reference in the guide.
+DEFAULT_SEARCH_TYPE = "auto"
+
+#: Valid ``type`` values accepted by ``POST /search``.
+VALID_SEARCH_TYPES = frozenset({"auto", "fast", "instant", "deep-lite", "deep", "deep-reasoning"})
+
+
+@dataclass(frozen=True)
+class ExaConfig:
+    """Immutable Exa client configuration.
+
+    Attributes:
+        api_key: Exa API key (sent as the ``x-api-key`` header).
+        base_url: REST host, without a trailing slash.
+        default_type: ``type`` used when a search call does not specify one.
+        timeout: Per-request timeout in seconds. Deep search types stack
+            latency, so allow generous headroom (default 60s).
+    """
+
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    default_type: str = DEFAULT_SEARCH_TYPE
+    timeout: float = 60.0
+
+    def __post_init__(self) -> None:
+        if not self.api_key or not str(self.api_key).strip():
+            raise ExaError(f"Exa API key is empty; set {API_KEY_ENV} or pass api_key explicitly")
+        if self.default_type not in VALID_SEARCH_TYPES:
+            raise ExaError(f"invalid default_type {self.default_type!r}; expected one of {sorted(VALID_SEARCH_TYPES)}")
+        # Normalise away a trailing slash so path joins stay clean.
+        object.__setattr__(self, "base_url", self.base_url.rstrip("/"))
+
+    @classmethod
+    def from_env(cls, *, base_url: str | None = None, **kwargs: object) -> ExaConfig:
+        """Build config from ``EXA_API_KEY``.
+
+        Raises:
+            ExaError: when the environment variable is unset or blank.
+        """
+        api_key = os.environ.get(API_KEY_ENV, "").strip()
+        if not api_key:
+            raise ExaError(f"{API_KEY_ENV} is not set in the environment")
+        return cls(api_key=api_key, base_url=base_url or DEFAULT_BASE_URL, **kwargs)  # type: ignore[arg-type]
+
+    def auth_headers(self) -> dict[str, str]:
+        """Headers every Exa request must carry."""
+        return {"x-api-key": self.api_key, "Content-Type": "application/json"}
+
+
+__all__ = [
+    "API_KEY_ENV",
+    "DEFAULT_BASE_URL",
+    "DEFAULT_SEARCH_TYPE",
+    "ExaConfig",
+    "VALID_SEARCH_TYPES",
+]

--- a/infrastructure/search/exa/contents/AGENTS.md
+++ b/infrastructure/search/exa/contents/AGENTS.md
@@ -1,0 +1,17 @@
+# `exa/contents` package (technical)
+
+`ExaContentsInterface` wraps `POST /contents` (`interface.py`). Returns
+`ContentsResponse`. Use for URLs you already have (DB, RSS, prior result `id`s)
+or to refresh stale content via `max_age_hours`.
+
+- Accepts a single URL or a sequence; empty input raises `ExaError`.
+- Defaults to `highlights=True` when no content mode is given.
+- **Content keys are top-level here** (`text`/`highlights`/`summary`), unlike
+  `/search` and `/findSimilar` where they nest under `contents`. The interface
+  handles this difference so callers never hit the documented mistake.
+
+## Tests
+
+```bash
+uv run pytest tests/infra_tests/search/test_exa.py -q   # pytest-httpserver, no mocks
+```

--- a/infrastructure/search/exa/contents/README.md
+++ b/infrastructure/search/exa/contents/README.md
@@ -1,0 +1,12 @@
+# `exa/contents` — `POST /contents`
+
+Clean parsed content for URLs you already have (from a DB, RSS, or prior search
+`id`s). `ExaContentsInterface.get(urls, ...)`.
+
+- Content keys (`highlights`/`text`/`summary`) are **top-level** here — unlike
+  `/search`, where they nest under `contents`.
+- `max_age_hours=0` forces a livecrawl; `-1` never livecrawls (cache only).
+
+```python
+client.contents(["https://example.com/post"], text={"maxCharacters": 20000})
+```

--- a/infrastructure/search/exa/contents/__init__.py
+++ b/infrastructure/search/exa/contents/__init__.py
@@ -1,0 +1,5 @@
+"""Exa ``/contents`` interface package."""
+
+from infrastructure.search.exa.contents.interface import ExaContentsInterface
+
+__all__ = ["ExaContentsInterface"]

--- a/infrastructure/search/exa/contents/interface.py
+++ b/infrastructure/search/exa/contents/interface.py
@@ -1,0 +1,64 @@
+"""``/contents`` interface — clean parsed content for URLs you already have.
+
+Use this when URLs come from another source (a database, RSS, prior search
+``id``s) or when you need to refresh stale content via ``max_age_hours``. On
+``/contents`` the content keys (``highlights``/``text``/``summary``) are
+top-level — unlike ``/search`` where they nest under ``contents``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from infrastructure.search.exa.errors import ExaError
+from infrastructure.search.exa.models import ContentsResponse, prune
+
+if TYPE_CHECKING:  # pragma: no cover
+    from infrastructure.search.exa.client import ExaClient
+
+
+class ExaContentsInterface:
+    """Wraps ``POST /contents``."""
+
+    path = "/contents"
+
+    def __init__(self, client: ExaClient) -> None:
+        self._client = client
+
+    def get(
+        self,
+        urls: str | Sequence[str],
+        *,
+        highlights: bool | Mapping[str, Any] | None = None,
+        text: bool | Mapping[str, Any] | None = None,
+        summary: bool | Mapping[str, Any] | None = None,
+        max_age_hours: int | None = None,
+        livecrawl_timeout: int | None = None,
+        subpages: int | None = None,
+    ) -> ContentsResponse:
+        """Fetch content for one or more URLs (or Exa result ``id``s).
+
+        Defaults to highlights when no content mode is given. Raises
+        :class:`ExaError` when no URLs are supplied.
+        """
+        url_list = [urls] if isinstance(urls, str) else list(urls)
+        url_list = [u for u in url_list if u and u.strip()]
+        if not url_list:
+            raise ExaError("contents requires at least one non-empty URL")
+        if highlights is None and text is None and summary is None:
+            highlights = True
+        payload = prune(
+            {
+                "urls": url_list,
+                "highlights": highlights,
+                "text": text,
+                "summary": summary,
+                "maxAgeHours": max_age_hours,
+                "livecrawlTimeout": livecrawl_timeout,
+                "subpages": subpages,
+            }
+        )
+        return ContentsResponse.from_dict(self._client.request(self.path, payload))
+
+
+__all__ = ["ExaContentsInterface"]

--- a/infrastructure/search/exa/errors.py
+++ b/infrastructure/search/exa/errors.py
@@ -1,0 +1,25 @@
+"""Exa search error type.
+
+Kept deliberately separate from :mod:`infrastructure.search.literature.base`
+so the Exa interface is a fully independent search interface under
+``infrastructure/search`` with no cross-import into the literature backends.
+"""
+
+from __future__ import annotations
+
+
+class ExaError(RuntimeError):
+    """Raised when an Exa request fails (transport, non-2xx status, or parse).
+
+    Carries the HTTP ``status`` and raw ``body`` when the failure is a non-2xx
+    API response, so callers can branch on, e.g., 401 (bad key) vs 400 (bad
+    request) without re-parsing.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None, body: str | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+__all__ = ["ExaError"]

--- a/infrastructure/search/exa/find_similar/AGENTS.md
+++ b/infrastructure/search/exa/find_similar/AGENTS.md
@@ -1,0 +1,17 @@
+# `exa/find_similar` package (technical)
+
+`ExaFindSimilarInterface` wraps `POST /findSimilar` (`interface.py`). Returns the
+same `SearchResponse` shape as `/search`; the query is a seed URL, not free text.
+This is the one interface that reliably populates `ExaResult.score`.
+
+- **Wire path is camelCase `/findSimilar`** — the kebab-case `/find-similar`
+  returns HTTP 404 (verified live). Do not "normalise" it.
+- Empty URL raises `ExaError`; defaults to `highlights=True`.
+- `exclude_source_domain=True` drops pages from the seed URL's own domain.
+- Content keys nest under `contents` (as for `/search`).
+
+## Tests
+
+```bash
+uv run pytest tests/infra_tests/search/test_exa.py -q   # pytest-httpserver, no mocks
+```

--- a/infrastructure/search/exa/find_similar/README.md
+++ b/infrastructure/search/exa/find_similar/README.md
@@ -1,0 +1,11 @@
+# `exa/find_similar` — `POST /findSimilar`
+
+Semantically similar pages for a seed URL. Same response shape as `/search`.
+`ExaFindSimilarInterface.find_similar(url, ...)`.
+
+- `exclude_source_domain=True` drops results from the seed URL's own domain.
+- Supports the same domain/date filters and `contents` content modes as search.
+
+```python
+client.find_similar("https://arxiv.org/abs/1706.03762", num_results=5, exclude_source_domain=True)
+```

--- a/infrastructure/search/exa/find_similar/__init__.py
+++ b/infrastructure/search/exa/find_similar/__init__.py
@@ -1,0 +1,5 @@
+"""Exa ``/findSimilar`` interface package."""
+
+from infrastructure.search.exa.find_similar.interface import ExaFindSimilarInterface
+
+__all__ = ["ExaFindSimilarInterface"]

--- a/infrastructure/search/exa/find_similar/interface.py
+++ b/infrastructure/search/exa/find_similar/interface.py
@@ -1,0 +1,76 @@
+"""``/findSimilar`` interface — semantically similar pages for a seed URL.
+
+Returns the same :class:`~infrastructure.search.exa.models.SearchResponse` shape
+as ``/search``; the difference is the query is a URL rather than free text.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from infrastructure.search.exa.errors import ExaError
+from infrastructure.search.exa.models import (
+    SearchResponse,
+    build_contents_payload,
+    prune,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from infrastructure.search.exa.client import ExaClient
+
+
+class ExaFindSimilarInterface:
+    """Wraps ``POST /findSimilar``."""
+
+    # Exa's live REST path is camelCase ``/findSimilar``; the kebab-case
+    # ``/find-similar`` form returns HTTP 404 (verified against the live API).
+    path = "/findSimilar"
+
+    def __init__(self, client: ExaClient) -> None:
+        self._client = client
+
+    def find_similar(
+        self,
+        url: str,
+        *,
+        num_results: int | None = None,
+        include_domains: Sequence[str] | None = None,
+        exclude_domains: Sequence[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        exclude_source_domain: bool | None = None,
+        highlights: bool | Mapping[str, Any] | None = None,
+        text: bool | Mapping[str, Any] | None = None,
+        summary: bool | Mapping[str, Any] | None = None,
+        max_age_hours: int | None = None,
+    ) -> SearchResponse:
+        """Find pages similar to ``url``.
+
+        Defaults to highlights when no content mode is requested. Raises
+        :class:`ExaError` on an empty URL.
+        """
+        if not url or not url.strip():
+            raise ExaError("find_similar requires a non-empty seed URL")
+        if highlights is None and text is None and summary is None:
+            highlights = True
+        payload = prune(
+            {
+                "url": url,
+                "numResults": num_results,
+                "includeDomains": list(include_domains) if include_domains else None,
+                "excludeDomains": list(exclude_domains) if exclude_domains else None,
+                "startPublishedDate": start_published_date,
+                "endPublishedDate": end_published_date,
+                "excludeSourceDomain": exclude_source_domain,
+                "contents": build_contents_payload(
+                    highlights=highlights,
+                    text=text,
+                    summary=summary,
+                    max_age_hours=max_age_hours,
+                ),
+            }
+        )
+        return SearchResponse.from_dict(self._client.request(self.path, payload))
+
+
+__all__ = ["ExaFindSimilarInterface"]

--- a/infrastructure/search/exa/http.py
+++ b/infrastructure/search/exa/http.py
@@ -1,0 +1,83 @@
+"""Minimal, injectable HTTP transport for the Exa client.
+
+Mirrors the design of :mod:`infrastructure.search.literature.http_client` (a
+structural :class:`ExaHttpClient` Protocol plus a stdlib implementation) but is
+kept Exa-local so the two search interfaces share no imports. Tests inject a
+fake transport or point :class:`UrllibExaHttpClient` at a ``pytest-httpserver``
+URL — no mocking framework, per the repository's no-mocks policy.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from infrastructure.search.exa.errors import ExaError
+
+
+@dataclass
+class ExaResponse:
+    """Minimal HTTP response wrapper."""
+
+    status_code: int
+    text: str
+    url: str
+
+    def json(self) -> Any:
+        try:
+            return _json.loads(self.text)
+        except _json.JSONDecodeError as exc:
+            raise ExaError(
+                f"Exa returned a non-JSON body (HTTP {self.status_code})",
+                status=self.status_code,
+                body=self.text[:500],
+            ) from exc
+
+
+class ExaHttpClient(Protocol):
+    """Structural type for the transport the client depends on."""
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: Any,
+        headers: dict[str, str],
+        timeout: float,
+    ) -> ExaResponse: ...  # pragma: no cover - protocol declaration
+
+
+class UrllibExaHttpClient:
+    """stdlib ``urllib`` POST client. Adequate for JSON REST calls."""
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: Any,
+        headers: dict[str, str],
+        timeout: float,
+    ) -> ExaResponse:
+        body = _json.dumps(json).encode("utf-8")
+        req = urllib.request.Request(url, data=body, headers=dict(headers), method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310 - host is configured, not user input
+                charset = resp.headers.get_content_charset() or "utf-8"
+                text = resp.read().decode(charset, errors="replace")
+                return ExaResponse(status_code=resp.status, text=text, url=resp.geturl())
+        except urllib.error.HTTPError as exc:
+            err_body = ""
+            try:
+                err_body = exc.read().decode("utf-8", errors="replace")
+            except (OSError, AttributeError):  # pragma: no cover - defensive
+                pass
+            # Non-2xx is returned, not raised, so the client can attach API context.
+            return ExaResponse(status_code=exc.code, text=err_body, url=url)
+        except urllib.error.URLError as exc:
+            raise ExaError(f"network error posting to {url}: {exc.reason}") from exc
+
+
+__all__ = ["ExaHttpClient", "ExaResponse", "UrllibExaHttpClient"]

--- a/infrastructure/search/exa/models.py
+++ b/infrastructure/search/exa/models.py
@@ -1,0 +1,251 @@
+"""Typed request/response models for the Exa search interfaces.
+
+Every endpoint returns the same normalised :class:`ExaResult` record (mirroring
+how the literature backends all emit a :class:`~infrastructure.search.literature.models.Paper`)
+so downstream consumers treat ``/search``, ``/contents``, ``/findSimilar`` and
+``/answer`` citations uniformly.
+
+Wire payloads are camelCase (e.g. ``numResults``); the Python surface is
+snake_case. ``build_contents_payload`` performs the one place where the two
+conventions meet, and guards the documented "common mistakes" (content keys must
+nest under ``contents``; ``category`` ``company``/``people`` reject domain and
+date filters).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from infrastructure.search.exa.errors import ExaError
+
+#: ``category`` values that reject ``excludeDomains`` and date filters (→ HTTP 400).
+_FILTER_RESTRICTED_CATEGORIES = frozenset({"company", "people"})
+
+
+@dataclass
+class ExaResult:
+    """A single Exa result, normalised across every endpoint.
+
+    ``id`` is the stable Exa document id used to re-fetch via ``/contents``;
+    ``url`` is the canonical landing page. Content fields (``text``,
+    ``highlights``, ``summary``) are populated only when the request asked for
+    them via the ``contents`` block.
+    """
+
+    id: str
+    url: str | None = None
+    title: str | None = None
+    score: float | None = None
+    published_date: str | None = None
+    author: str | None = None
+    text: str | None = None
+    highlights: list[str] = field(default_factory=list)
+    highlight_scores: list[float] = field(default_factory=list)
+    summary: str | None = None
+    image: str | None = None
+    favicon: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ExaResult:
+        return cls(
+            id=str(data.get("id") or data.get("url") or ""),
+            url=data.get("url"),
+            title=data.get("title"),
+            score=_as_float(data.get("score")),
+            published_date=data.get("publishedDate"),
+            author=data.get("author"),
+            text=data.get("text"),
+            highlights=list(data.get("highlights") or []),
+            highlight_scores=[f for f in (_as_float(s) for s in data.get("highlightScores") or []) if f is not None],
+            summary=data.get("summary"),
+            image=data.get("image"),
+            favicon=data.get("favicon"),
+            extras=dict(data.get("extras") or {}),
+            raw=dict(data),
+        )
+
+
+@dataclass
+class Grounding:
+    """Field-level citation record returned when ``outputSchema`` is used."""
+
+    field: str
+    citations: list[dict[str, Any]] = field(default_factory=list)
+    confidence: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> Grounding:
+        return cls(
+            field=str(data.get("field", "")),
+            citations=list(data.get("citations") or []),
+            confidence=data.get("confidence"),
+        )
+
+
+@dataclass
+class SearchOutput:
+    """Synthesised output from ``outputSchema`` searches (``output`` block)."""
+
+    content: Any = None
+    grounding: list[Grounding] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> SearchOutput:
+        return cls(
+            content=data.get("content"),
+            grounding=[Grounding.from_dict(g) for g in data.get("grounding") or []],
+        )
+
+
+@dataclass
+class SearchResponse:
+    """Response from ``POST /search`` (and ``/findSimilar``, same shape)."""
+
+    results: list[ExaResult] = field(default_factory=list)
+    request_id: str | None = None
+    search_type: str | None = None
+    output: SearchOutput | None = None
+    cost_dollars: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> SearchResponse:
+        output = data.get("output")
+        cost = data.get("costDollars")
+        return cls(
+            results=[ExaResult.from_dict(r) for r in data.get("results") or []],
+            request_id=data.get("requestId"),
+            search_type=data.get("searchType"),
+            output=SearchOutput.from_dict(output) if isinstance(output, Mapping) else None,
+            cost_dollars=_as_float(cost.get("total")) if isinstance(cost, Mapping) else _as_float(cost),
+            raw=dict(data),
+        )
+
+
+@dataclass
+class ContentsResponse:
+    """Response from ``POST /contents``."""
+
+    results: list[ExaResult] = field(default_factory=list)
+    request_id: str | None = None
+    cost_dollars: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ContentsResponse:
+        cost = data.get("costDollars")
+        return cls(
+            results=[ExaResult.from_dict(r) for r in data.get("results") or []],
+            request_id=data.get("requestId"),
+            cost_dollars=_as_float(cost.get("total")) if isinstance(cost, Mapping) else _as_float(cost),
+            raw=dict(data),
+        )
+
+
+@dataclass
+class AnswerResponse:
+    """Response from ``POST /answer`` — a grounded answer plus its citations."""
+
+    answer: Any = None
+    citations: list[ExaResult] = field(default_factory=list)
+    request_id: str | None = None
+    cost_dollars: float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> AnswerResponse:
+        cost = data.get("costDollars")
+        return cls(
+            answer=data.get("answer"),
+            citations=[ExaResult.from_dict(c) for c in data.get("citations") or []],
+            request_id=data.get("requestId"),
+            cost_dollars=_as_float(cost.get("total")) if isinstance(cost, Mapping) else _as_float(cost),
+            raw=dict(data),
+        )
+
+
+def build_contents_payload(
+    *,
+    highlights: bool | Mapping[str, Any] | None = None,
+    text: bool | Mapping[str, Any] | None = None,
+    summary: bool | Mapping[str, Any] | None = None,
+    max_age_hours: int | None = None,
+    livecrawl_timeout: int | None = None,
+    subpages: int | None = None,
+) -> dict[str, Any]:
+    """Build the nested ``contents`` object from snake_case kwargs.
+
+    Returns ``{}`` when nothing was requested so callers can drop the key. Note
+    the guide's guardrail: content keys must NEVER appear at the top level of a
+    ``/search`` body — only inside this object.
+    """
+    contents: dict[str, Any] = {}
+    if highlights is not None:
+        contents["highlights"] = highlights
+    if text is not None:
+        contents["text"] = text
+    if summary is not None:
+        contents["summary"] = summary
+    if max_age_hours is not None:
+        contents["maxAgeHours"] = max_age_hours
+    if livecrawl_timeout is not None:
+        contents["livecrawlTimeout"] = livecrawl_timeout
+    if subpages is not None:
+        contents["subpages"] = subpages
+    return contents
+
+
+def validate_search_request(
+    *,
+    category: str | None,
+    exclude_domains: Sequence[str] | None,
+    start_published_date: str | None,
+    end_published_date: str | None,
+) -> None:
+    """Fail fast on the documented ``category`` filter conflict (HTTP 400).
+
+    ``company`` and ``people`` categories reject ``excludeDomains`` and date
+    filters; catching it here gives a clear error instead of a server 400.
+    """
+    if category in _FILTER_RESTRICTED_CATEGORIES and (exclude_domains or start_published_date or end_published_date):
+        raise ExaError(
+            f"category={category!r} does not support excludeDomains or date filters "
+            "(Exa returns HTTP 400); drop those filters or change the category"
+        )
+
+
+def prune(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Drop ``None`` values and empty ``contents``/collections from a payload."""
+    out: dict[str, Any] = {}
+    for key, value in payload.items():
+        if value is None:
+            continue
+        if key == "contents" and not value:
+            continue
+        out[key] = value
+    return out
+
+
+def _as_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "AnswerResponse",
+    "ContentsResponse",
+    "ExaResult",
+    "Grounding",
+    "SearchOutput",
+    "SearchResponse",
+    "build_contents_payload",
+    "prune",
+    "validate_search_request",
+]

--- a/infrastructure/search/exa/search/AGENTS.md
+++ b/infrastructure/search/exa/search/AGENTS.md
@@ -1,0 +1,18 @@
+# `exa/search` package (technical)
+
+`ExaSearchInterface` wraps `POST /search` (`interface.py`). Returns `SearchResponse`.
+
+- Default content mode is `highlights=True` when no `text`/`summary`/`highlights`
+  is requested. Content keys nest under `contents` on the wire (camelCase).
+- `output_schema=` (+ `system_prompt=`) → synthesised JSON in `response.output`
+  with field-level `grounding` (citations + confidence). Works on every `type`.
+- Fail-fast guards (raise `ExaError` before the request): empty query, invalid
+  `type` (see `config.VALID_SEARCH_TYPES`), and `category` `company`/`people`
+  combined with `exclude_domains` or date filters (Exa returns HTTP 400).
+- `None` kwargs are pruned from the payload (`models.prune`).
+
+## Tests
+
+```bash
+uv run pytest tests/infra_tests/search/test_exa.py -q   # pytest-httpserver, no mocks
+```

--- a/infrastructure/search/exa/search/README.md
+++ b/infrastructure/search/exa/search/README.md
@@ -1,0 +1,14 @@
+# `exa/search` — `POST /search`
+
+Exa's primary neural/keyword search. `ExaSearchInterface.search(query, ...)`.
+
+- Defaults to token-efficient **highlights**; pass `text=`/`summary=` to change.
+- Pass `output_schema=` (+ `system_prompt=`) for synthesised, grounded JSON in
+  `response.output` (works on every `type`).
+- `type`: `auto` (default) · `fast` · `instant` · `deep-lite` · `deep` · `deep-reasoning`.
+- Guards: empty query, invalid `type`, and the `category` `company`/`people`
+  filter conflict all raise `ExaError` before the request.
+
+```python
+client.search("rust async runtime comparison", num_results=10, include_domains=["docs.rs"])
+```

--- a/infrastructure/search/exa/search/__init__.py
+++ b/infrastructure/search/exa/search/__init__.py
@@ -1,0 +1,5 @@
+"""Exa ``/search`` interface package."""
+
+from infrastructure.search.exa.search.interface import ExaSearchInterface
+
+__all__ = ["ExaSearchInterface"]

--- a/infrastructure/search/exa/search/interface.py
+++ b/infrastructure/search/exa/search/interface.py
@@ -1,0 +1,110 @@
+"""``/search`` interface — Exa's primary neural/keyword search endpoint.
+
+Covers raw retrieval (``results`` + ``highlights``) and synthesised structured
+output (``outputSchema`` + ``systemPrompt``). All wire fields are camelCase; the
+Python surface is snake_case and ``None`` arguments are pruned from the body.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+from infrastructure.search.exa.config import VALID_SEARCH_TYPES
+from infrastructure.search.exa.errors import ExaError
+from infrastructure.search.exa.models import (
+    SearchResponse,
+    build_contents_payload,
+    prune,
+    validate_search_request,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from infrastructure.search.exa.client import ExaClient
+
+
+class ExaSearchInterface:
+    """Wraps ``POST /search``."""
+
+    path = "/search"
+
+    def __init__(self, client: ExaClient) -> None:
+        self._client = client
+
+    def search(
+        self,
+        query: str,
+        *,
+        type: str | None = None,
+        num_results: int | None = None,
+        category: str | None = None,
+        user_location: str | None = None,
+        include_domains: Sequence[str] | None = None,
+        exclude_domains: Sequence[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        moderation: bool | None = None,
+        # content retrieval (nested under `contents`)
+        highlights: bool | Mapping[str, Any] | None = None,
+        text: bool | Mapping[str, Any] | None = None,
+        summary: bool | Mapping[str, Any] | None = None,
+        max_age_hours: int | None = None,
+        livecrawl_timeout: int | None = None,
+        subpages: int | None = None,
+        # synthesised structured output
+        output_schema: Mapping[str, Any] | None = None,
+        system_prompt: str | None = None,
+        additional_queries: Sequence[str] | None = None,
+    ) -> SearchResponse:
+        """Run a search.
+
+        Defaults to raw retrieval with highlights (the token-efficient mode the
+        coding-agent guide recommends). Pass ``output_schema`` to get Exa to
+        synthesise grounded JSON in ``response.output``.
+
+        Raises:
+            ExaError: empty query, invalid ``type``, or a ``category`` that
+                conflicts with the requested filters.
+        """
+        if not query or not query.strip():
+            raise ExaError("search query must be a non-empty string")
+        resolved_type = type or self._client.config.default_type
+        if resolved_type not in VALID_SEARCH_TYPES:
+            raise ExaError(f"invalid type {resolved_type!r}; expected one of {sorted(VALID_SEARCH_TYPES)}")
+        validate_search_request(
+            category=category,
+            exclude_domains=exclude_domains,
+            start_published_date=start_published_date,
+            end_published_date=end_published_date,
+        )
+        # Default to highlights when no content mode was requested at all.
+        if highlights is None and text is None and summary is None:
+            highlights = True
+        payload = prune(
+            {
+                "query": query,
+                "type": resolved_type,
+                "numResults": num_results,
+                "category": category,
+                "userLocation": user_location,
+                "includeDomains": list(include_domains) if include_domains else None,
+                "excludeDomains": list(exclude_domains) if exclude_domains else None,
+                "startPublishedDate": start_published_date,
+                "endPublishedDate": end_published_date,
+                "moderation": moderation,
+                "outputSchema": dict(output_schema) if output_schema else None,
+                "systemPrompt": system_prompt,
+                "additionalQueries": list(additional_queries) if additional_queries else None,
+                "contents": build_contents_payload(
+                    highlights=highlights,
+                    text=text,
+                    summary=summary,
+                    max_age_hours=max_age_hours,
+                    livecrawl_timeout=livecrawl_timeout,
+                    subpages=subpages,
+                ),
+            }
+        )
+        return SearchResponse.from_dict(self._client.request(self.path, payload))
+
+
+__all__ = ["ExaSearchInterface"]

--- a/infrastructure/search/literature/__main__.py
+++ b/infrastructure/search/literature/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m infrastructure.search.literature`` entry point."""
+
+from infrastructure.search.literature.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infrastructure/search/literature/fulltext.py
+++ b/infrastructure/search/literature/fulltext.py
@@ -246,13 +246,9 @@ class FulltextFetcher:
             )
 
         try:
-            resp = self.http.get(url, timeout=self.timeout)
+            pdf_bytes = self.http.get_bytes(url, timeout=self.timeout)
         except BackendError as exc:
             return FetchResult(paper=paper, status="error", message=str(exc))
-        if resp.status_code != 200:
-            return FetchResult(paper=paper, status="error", message=f"HTTP {resp.status_code}")
-
-        pdf_bytes = resp.text.encode("latin-1", errors="ignore")
         # Write PDF to cache regardless of whether we can extract text.
         path: Path | None = None
         if cache is not None:

--- a/infrastructure/search/literature/http_client.py
+++ b/infrastructure/search/literature/http_client.py
@@ -36,6 +36,15 @@ class HttpClient(Protocol):
         timeout: float = 10.0,
     ) -> HttpResponse: ...  # pragma: no cover
 
+    def get_bytes(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float = 10.0,
+    ) -> bytes: ...  # pragma: no cover
+
     def post(
         self,
         url: str,
@@ -75,6 +84,33 @@ class UrllibHttpClient:
             except (OSError, AttributeError):  # pragma: no cover
                 pass
             return HttpResponse(status_code=exc.code, text=body, url=url)
+        except urllib.error.URLError as exc:
+            raise BackendError(f"HTTP error fetching {url}: {exc.reason}") from exc
+
+    def get_bytes(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float = 10.0,
+    ) -> bytes:
+        """Fetch raw response bytes (for binary payloads like PDFs).
+
+        Unlike :meth:`get`, this does NOT decode the body as text — decoding a
+        PDF as text and re-encoding corrupts every non-ASCII byte. Raises
+        :class:`BackendError` on any non-2xx status or transport error.
+        """
+        if params:
+            qs = urllib.parse.urlencode(params, doseq=True)
+            sep = "&" if "?" in url else "?"
+            url = f"{url}{sep}{qs}"
+        req = urllib.request.Request(url, headers=dict(headers or {}))
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310
+                return resp.read()
+        except urllib.error.HTTPError as exc:
+            raise BackendError(f"HTTP {exc.code} fetching {url}") from exc
         except urllib.error.URLError as exc:
             raise BackendError(f"HTTP error fetching {url}: {exc.reason}") from exc
 

--- a/tests/infra_tests/bench/test_template_benchmark_harness.py
+++ b/tests/infra_tests/bench/test_template_benchmark_harness.py
@@ -176,3 +176,25 @@ benchmark_rubric:
     assert manifest.rubric is not None
     assert manifest.rubric.name == "code-rubric"
     assert manifest.rubric.dimensions[0].weight == 3.0
+
+
+def test_checked_in_smoke_manifest_projects_resolve_on_disk() -> None:
+    """The committed smoke manifest's project names must resolve to real dirs.
+
+    Regression guard: the manifest previously held bare names
+    ("template_code_project") that resolved to projects/<name>, but the public
+    exemplars live under projects/templates/. Without binding the file to disk,
+    a project move silently makes every benchmark check score 0 / "missing"
+    while the unit tests (which construct their own manifests) stay green.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    manifest_path = (
+        repo_root / "infrastructure" / "benchmark" / "template_smoke_manifest.json"
+    )
+    manifest = load_benchmark_manifest(manifest_path)
+    assert manifest.projects, "smoke manifest lists no projects"
+    for name in manifest.projects:
+        assert (repo_root / "projects" / name).is_dir(), (
+            f"manifest project {name!r} does not resolve to a directory under "
+            "projects/ — qualify it (e.g. templates/<name>) or update the move"
+        )

--- a/tests/infra_tests/scientific/test_stability.py
+++ b/tests/infra_tests/scientific/test_stability.py
@@ -227,15 +227,21 @@ class TestCheckNumericalStability:
         assert result.stability_score < 1.0
 
     def test_custom_tolerance(self):
-        """Test with custom tolerance parameter."""
+        """tolerance is a live knob: flipping it changes the stability score.
 
-        def precise_function(x):
-            return x + 1e-15  # Very small perturbation
+        A finite, non-zero result of 1e-15 is "stable" under a loose tolerance
+        but "near-underflow" under a strict one — so the score must drop.
+        """
+
+        def underflow_function(x):
+            return 1e-15  # finite, non-zero, tiny magnitude
 
         test_inputs = [1.0, 2.0, 3.0]
-        result = check_numerical_stability(precise_function, test_inputs, tolerance=1e-20)
+        loose = check_numerical_stability(underflow_function, test_inputs, tolerance=1e-20)
+        strict = check_numerical_stability(underflow_function, test_inputs, tolerance=1e-12)
 
-        assert result.stability_score == 1.0
+        assert loose.stability_score == 1.0  # 1e-15 not below 1e-20 → stable
+        assert strict.stability_score < loose.stability_score  # 1e-15 < 1e-12 → flagged
 
     def test_input_range_calculation(self):
         """Test input range is correctly calculated."""

--- a/tests/infra_tests/search/test_exa.py
+++ b/tests/infra_tests/search/test_exa.py
@@ -1,0 +1,289 @@
+"""Exa search-interface tests using pytest-httpserver (no mocks).
+
+Every test drives the real :class:`UrllibExaHttpClient` against a local
+``pytest-httpserver``; the only override is ``base_url``. This exercises the
+actual transport, header, URL-join, and JSON parse paths end to end.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from infrastructure.search.exa import (
+    AnswerResponse,
+    ContentsResponse,
+    ExaClient,
+    ExaConfig,
+    ExaError,
+    ExaResult,
+    SearchResponse,
+)
+from infrastructure.search.exa.cli import build_parser, run
+from infrastructure.search.exa.models import build_contents_payload, prune, validate_search_request
+
+
+def _client(httpserver: HTTPServer) -> ExaClient:
+    base = httpserver.url_for("/").rstrip("/")
+    return ExaClient(ExaConfig(api_key="test-key", base_url=base))
+
+
+# --------------------------------------------------------------------------- #
+# /search
+# --------------------------------------------------------------------------- #
+
+
+def test_search_parses_real_payload(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/search", method="POST").respond_with_json(
+        {
+            "requestId": "req-1",
+            "searchType": "auto",
+            "results": [
+                {
+                    "id": "doc-1",
+                    "url": "https://example.com/a",
+                    "title": "Auth example",
+                    "publishedDate": "2024-03-01",
+                    "author": "Jane",
+                    "highlights": ["use a route handler"],
+                    "highlightScores": [0.91],
+                }
+            ],
+            "costDollars": {"total": 0.005},
+        }
+    )
+    resp = _client(httpserver).search("auth example", num_results=10)
+    assert isinstance(resp, SearchResponse)
+    assert resp.request_id == "req-1" and resp.search_type == "auto"
+    assert resp.cost_dollars == pytest.approx(0.005)
+    assert len(resp.results) == 1
+    assert resp.results[0].id == "doc-1"
+    assert resp.results[0].highlights == ["use a route handler"]
+    assert resp.results[0].highlight_scores == [pytest.approx(0.91)]
+
+
+def test_search_sends_camelcase_with_nested_contents_and_auth(httpserver: HTTPServer) -> None:
+    captured: dict = {}
+
+    def handler(request):  # type: ignore[no-untyped-def]
+        captured["headers"] = dict(request.headers)
+        captured["json"] = json.loads(request.get_data())
+        from werkzeug.wrappers import Response
+
+        return Response(json.dumps({"requestId": "r", "results": []}), content_type="application/json")
+
+    httpserver.expect_request("/search", method="POST").respond_with_handler(handler)
+    _client(httpserver).search(
+        "query",
+        type="fast",
+        num_results=7,
+        include_domains=["arxiv.org"],
+        exclude_domains=["pinterest.com"],
+    )
+    body = captured["json"]
+    # camelCase wire field names, default highlights nested under `contents`.
+    assert body["type"] == "fast" and body["numResults"] == 7
+    assert body["includeDomains"] == ["arxiv.org"] and body["excludeDomains"] == ["pinterest.com"]
+    assert body["contents"] == {"highlights": True}
+    # content keys must NOT leak to the top level (documented mistake).
+    assert "highlights" not in body and "text" not in body and "summary" not in body
+    assert captured["headers"]["X-Api-Key"] == "test-key"
+
+
+def test_search_structured_output_and_grounding(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/search", method="POST").respond_with_json(
+        {
+            "requestId": "r",
+            "results": [],
+            "output": {
+                "content": {"companies": [{"name": "Nvidia"}]},
+                "grounding": [
+                    {"field": "companies[0].name", "citations": [{"url": "u", "title": "t"}], "confidence": "high"}
+                ],
+            },
+        }
+    )
+    resp = _client(httpserver).search("gpus", output_schema={"type": "object"}, system_prompt="prefer official")
+    assert resp.output is not None
+    assert resp.output.content == {"companies": [{"name": "Nvidia"}]}
+    assert resp.output.grounding[0].field == "companies[0].name"
+    assert resp.output.grounding[0].confidence == "high"
+
+
+def test_search_rejects_empty_query() -> None:
+    client = ExaClient(ExaConfig(api_key="k"))
+    with pytest.raises(ExaError, match="non-empty"):
+        client.search("   ")
+
+
+def test_search_rejects_invalid_type() -> None:
+    client = ExaClient(ExaConfig(api_key="k"))
+    with pytest.raises(ExaError, match="invalid type"):
+        client.search("q", type="turbo")
+
+
+# --------------------------------------------------------------------------- #
+# /contents, /answer, /find-similar
+# --------------------------------------------------------------------------- #
+
+
+def test_contents_uses_top_level_content_keys(httpserver: HTTPServer) -> None:
+    captured: dict = {}
+
+    def handler(request):  # type: ignore[no-untyped-def]
+        captured["json"] = json.loads(request.get_data())
+        from werkzeug.wrappers import Response
+
+        return Response(
+            json.dumps({"requestId": "c", "results": [{"id": "d", "url": "u", "text": "body"}]}),
+            content_type="application/json",
+        )
+
+    httpserver.expect_request("/contents", method="POST").respond_with_handler(handler)
+    resp = _client(httpserver).contents(["https://u.com"], text=True)
+    assert isinstance(resp, ContentsResponse) and resp.results[0].text == "body"
+    # On /contents the content keys are top-level (NOT nested under `contents`).
+    assert captured["json"] == {"urls": ["https://u.com"], "text": True}
+
+
+def test_contents_rejects_empty_urls() -> None:
+    with pytest.raises(ExaError, match="at least one"):
+        ExaClient(ExaConfig(api_key="k")).contents([" "])
+
+
+def test_answer_parses_citations(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/answer", method="POST").respond_with_json(
+        {
+            "requestId": "a",
+            "answer": "RAG combines retrieval with generation.",
+            "citations": [{"id": "c", "url": "u", "title": "src"}],
+        }
+    )
+    resp = _client(httpserver).answer("what is RAG?")
+    assert isinstance(resp, AnswerResponse)
+    assert resp.answer.startswith("RAG") and resp.citations[0].title == "src"
+
+
+def test_find_similar_returns_search_shape(httpserver: HTTPServer) -> None:
+    captured: dict = {}
+
+    def handler(request):  # type: ignore[no-untyped-def]
+        captured["json"] = json.loads(request.get_data())
+        from werkzeug.wrappers import Response
+
+        return Response(
+            json.dumps({"requestId": "s", "results": [{"id": "sim", "url": "v"}]}), content_type="application/json"
+        )
+
+    httpserver.expect_request("/findSimilar", method="POST").respond_with_handler(handler)
+    resp = _client(httpserver).find_similar("https://seed.com", num_results=3, exclude_source_domain=True)
+    assert resp.results[0].id == "sim"
+    assert captured["json"]["url"] == "https://seed.com"
+    assert captured["json"]["numResults"] == 3 and captured["json"]["excludeSourceDomain"] is True
+
+
+# --------------------------------------------------------------------------- #
+# Errors, config, models
+# --------------------------------------------------------------------------- #
+
+
+def test_non_2xx_raises_with_status_and_body(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/search", method="POST").respond_with_json({"error": "bad request"}, status=400)
+    with pytest.raises(ExaError) as excinfo:
+        _client(httpserver).search("q")
+    assert excinfo.value.status == 400 and "bad request" in (excinfo.value.body or "")
+
+
+def test_non_json_body_raises(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/search", method="POST").respond_with_data(
+        "<html>not json</html>", content_type="text/html"
+    )
+    with pytest.raises(ExaError, match="non-JSON"):
+        _client(httpserver).search("q")
+
+
+def test_config_from_env(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("EXA_API_KEY", "env-key")
+    cfg = ExaConfig.from_env()
+    assert cfg.api_key == "env-key" and cfg.base_url == "https://api.exa.ai"
+    assert cfg.auth_headers()["x-api-key"] == "env-key"
+
+
+def test_config_from_env_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    with pytest.raises(ExaError, match="not set"):
+        ExaConfig.from_env()
+
+
+def test_config_strips_trailing_slash_and_validates_type() -> None:
+    cfg = ExaConfig(api_key="k", base_url="https://api.exa.ai/")
+    assert cfg.base_url == "https://api.exa.ai"
+    with pytest.raises(ExaError, match="invalid default_type"):
+        ExaConfig(api_key="k", default_type="turbo")
+
+
+def test_validate_search_request_category_conflict() -> None:
+    with pytest.raises(ExaError, match="does not support"):
+        validate_search_request(
+            category="company", exclude_domains=["x.com"], start_published_date=None, end_published_date=None
+        )
+    # No conflict for an unrestricted category.
+    validate_search_request(
+        category="news", exclude_domains=["x.com"], start_published_date=None, end_published_date=None
+    )
+
+
+def test_build_contents_payload_and_prune() -> None:
+    assert build_contents_payload() == {}
+    assert build_contents_payload(highlights=True, max_age_hours=0) == {"highlights": True, "maxAgeHours": 0}
+    assert prune({"a": None, "b": 1, "contents": {}}) == {"b": 1}
+
+
+def test_exaresult_from_dict_tolerates_missing_fields() -> None:
+    r = ExaResult.from_dict({"url": "https://u.com"})
+    assert r.id == "https://u.com" and r.title is None and r.highlights == []
+
+
+# --------------------------------------------------------------------------- #
+# CLI (thin orchestrator)
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_search_roundtrip(httpserver: HTTPServer, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    httpserver.expect_request("/search", method="POST").respond_with_json(
+        {"requestId": "cli", "results": [{"id": "d", "url": "u", "title": "T"}]}
+    )
+    monkeypatch.setenv("EXA_API_KEY", "cli-key")
+    args = build_parser().parse_args(
+        ["--base-url", httpserver.url_for("/").rstrip("/"), "search", "hello", "--num-results", "2"]
+    )
+    out = run(args)
+    assert out["requestId"] == "cli" and out["results"][0]["id"] == "d"
+
+
+def test_cli_contents_answer_findsimilar(httpserver: HTTPServer, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("EXA_API_KEY", "k")
+    base = httpserver.url_for("/").rstrip("/")
+    httpserver.expect_request("/contents", method="POST").respond_with_json(
+        {"requestId": "c", "results": [{"id": "d", "url": "u"}]}
+    )
+    httpserver.expect_request("/answer", method="POST").respond_with_json(
+        {"requestId": "a", "answer": "yes", "citations": []}
+    )
+    httpserver.expect_request("/findSimilar", method="POST").respond_with_json(
+        {"requestId": "s", "results": [{"id": "sim", "url": "v"}]}
+    )
+    p = build_parser()
+    assert run(p.parse_args(["--base-url", base, "contents", "https://u.com", "--text"]))["requestId"] == "c"
+    assert run(p.parse_args(["--base-url", base, "answer", "what?"]))["answer"] == "yes"
+    assert run(p.parse_args(["--base-url", base, "find-similar", "https://seed.com"]))["results"][0]["id"] == "sim"
+
+
+def test_cli_reports_error_on_missing_key(monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    from infrastructure.search.exa.cli import main
+
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    assert main(["search", "q"]) == 1
+    assert "error:" in capsys.readouterr().err

--- a/tests/infra_tests/search/test_fulltext.py
+++ b/tests/infra_tests/search/test_fulltext.py
@@ -137,6 +137,19 @@ class TestFulltextFetcher:
         fetcher.fetch(p)
         assert (tmp_path / f"{_safe_id('x:1')}.pdf").exists()
 
+    def test_pdf_bytes_cached_without_corruption(self, httpserver: HTTPServer, tmp_path: Path):
+        # PDF payload with non-ASCII bytes (>0x7F). The previous text->latin-1
+        # round-trip replaced every non-decodable byte with U+FFFD, corrupting
+        # the cached PDF; get_bytes must persist the payload byte-for-byte.
+        payload = b"%PDF-1.4\n\xff\xfe\x80\x00binary\xc3\xa9\n%%EOF\n"
+        httpserver.expect_request("/raw.pdf").respond_with_data(payload, content_type="application/pdf")
+        fetcher = FulltextFetcher(cache_dir=tmp_path)
+        p = Paper(id="x:2", title="t", pdf_url=httpserver.url_for("/raw.pdf"))
+        fetcher.fetch(p)
+        cached = tmp_path / f"{_safe_id('x:2')}.pdf"
+        assert cached.exists()
+        assert cached.read_bytes() == payload  # byte-identical: no decode corruption
+
     def test_cached_text_short_circuits(self, tmp_path: Path):
         text_path = tmp_path / f"{_safe_id('arxiv:1')}.txt"
         text_path.write_text("cached body", encoding="utf-8")

--- a/tests/infra_tests/steganography/test_barcodes.py
+++ b/tests/infra_tests/steganography/test_barcodes.py
@@ -17,6 +17,14 @@ class TestBarcodes:
         assert isinstance(png_bytes, bytes)
         assert len(png_bytes) > 100
 
+    def test_generate_code128(self):
+        from infrastructure.steganography.barcodes import generate_code128
+
+        svg_bytes = generate_code128("ID:test123|P:1")
+        assert isinstance(svg_bytes, bytes)
+        assert len(svg_bytes) > 100
+        assert b"<svg" in svg_bytes or b"<?xml" in svg_bytes
+
     def test_build_barcode_payload(self):
         from infrastructure.steganography.barcodes import build_barcode_payload
 

--- a/tests/infra_tests/test_module_entrypoints.py
+++ b/tests/infra_tests/test_module_entrypoints.py
@@ -1,0 +1,43 @@
+"""Guard: every documented ``python -m <pkg>`` entrypoint must actually run.
+
+Several CLIs advertise a package-level invocation (``python -m infrastructure.x``)
+in their help text / docs. That only works if the package ships a ``__main__.py``.
+This test exercises the *real* subprocess invocation (not a direct ``main``
+import) so a missing ``__main__.py`` is caught here instead of by a user.
+
+No mocks: a real subprocess per entrypoint, asserting ``--help`` exits 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Packages whose help text / docs advertise ``python -m <name>``.
+_ENTRYPOINTS = [
+    "infrastructure.search.exa",
+    "infrastructure.search.literature",
+    "infrastructure.reference.citation",
+    "infrastructure.llm.cli",
+]
+
+
+@pytest.mark.parametrize("module", _ENTRYPOINTS)
+def test_module_entrypoint_help_exits_zero(module: str) -> None:
+    """``python -m <module> --help`` must exit 0 (package has a runnable __main__)."""
+    result = subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"`python -m {module} --help` exited {result.returncode}; "
+        f"a documented entrypoint is not runnable.\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Re-lands the infrastructure audit/fix work that was orphaned when PR #11's branch
was rebased and squash-merged without these commits.

## Contents
- **Exa search client** (`infrastructure/search/exa/`) — stdlib-only client for
  search / contents / answer / find_similar + CLI + per-interface README/AGENTS +
  `CAPABILITIES.md`; live-verified. (`/find-similar` → `/findSimilar` 404 fix.)
- **Tier-2 fixes** — literature binary-PDF corruption (`HttpClient.get_bytes()` +
  byte-fidelity test); `check_numerical_stability` dead `tolerance` knob wired
  into a near-underflow detector (test proves it); doctor unreachable exit-code-4
  removed from the agent contract; steganography `generate_code128` locked by test.
- **Layering refactor** — `resolve_project_root` + `NON_RENDERED_SUBDIRS` moved to
  `infrastructure/core/project_paths.py` so `core/files` + `core/runtime` no longer
  import up into `infrastructure.project`; `project.discovery` re-exports them with
  an explicit `__all__` (api_design rule). All external call sites unchanged.
- **Dead code / entrypoints / dedupe** — removed dead code (prose/orchestration/
  rendering; `sia/live_llm.py` was deleted upstream, honored); added `__main__.py`
  for the documented `python -m` entrypoints (llm.cli, search.literature,
  reference.citation) + guard test; deduped `VERBATIM_FIELDS`; fixed the benchmark
  smoke manifest + disk-binding guard.
- **Generated-doc refresh** — regenerated `api-reference.md` (new exa + discovery
  `__all__`) and bumped the canonical infra `.py` count 484→504.

## Verification (local, off current main)
- ruff format + check, mypy (17 files), module-line-count gate, api-reference
  `--check`, lint_docs — all green.
- **698 targeted tests pass** (search/reference/scientific/doctor/steganography/
  prose/orchestration/entrypoints/discovery). Full deep-import: 0 failures.

Branch-specific commits from the original PR (sheaf ruff-format, sheaf line-count
allowlist, test_linking/git_guards regression fixes) were intentionally **dropped**
— main handled those itself (line-count gate passes without the allowlist).