### PR TITLE
ci: split Project Tests into one parallel job per exemplar (~45min → ~slowest-project)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -66,8 +66,8 @@ in a job `if:` and rejects the whole workflow at parse).**
 | 3 | `health` | Unified Health Report (informational) | lint | 3.12 | ubuntu |
 | 4 | `verify-no-mocks` | Verify No Mocks Policy | lint | 3.12 | ubuntu |
 | 5 | `setup-hook-windows-smoke` | Setup hook (Windows smoke) | verify-no-mocks, detect | 3.12 | windows · runs iff `needs.detect.outputs.setup_hook == 'true'` |
-| 6 | `test-infra` | Infra Tests (matrix) | verify-no-mocks | 3.10–3.12 | ubuntu+macos |
-| 7 | `test-project` | Project Tests (matrix) | verify-no-mocks | 3.10–3.12 | ubuntu+macos |
+| 6 | `test-infra` | Infra Tests (matrix) | verify-no-mocks | 3.10–3.12 | ubuntu (×3.10/3.11/3.12) + macOS (3.12 only) — 4 cells |
+| 7 | `test-project` | Project Tests (per-project matrix) | verify-no-mocks | 3.10 + 3.12 | ubuntu only — 9 exemplars × 2 Python = 18 cells |
 | 8 | `fep-lean` | fep_lean (gauss + lake) | verify-no-mocks, detect | 3.12 | ubuntu · runs iff `needs.detect.outputs.fep_lean == 'true'` |
 | 9 | `validate` | Validate Manuscripts | lint | 3.12 | ubuntu |
 | 10 | `security` | Security Scan | lint | 3.12 | ubuntu |
@@ -142,7 +142,12 @@ severity as the CI `security` job, so contributors hear it before CI does.
 
 ## Branch Protection (Recommended)
 
-Required checks must match the **`name:`** field of each job in [`workflows/ci.yml`](workflows/ci.yml). Matrix jobs expand to **Infra Tests (`<os>`, Python `<ver>`)** and **Project Tests (`<os>`, Python `<ver>`)** — require the combinations you care about (e.g. ubuntu-latest × 3.10/3.11/3.12), or use GitHub rulesets that treat required checks flexibly.
+Required checks must match the **`name:`** field of each job in [`workflows/ci.yml`](workflows/ci.yml). `main` is currently unprotected, so the contexts below are **illustrative**. Matrix jobs expand to one check per cell:
+
+- **`test-infra`** → **Infra Tests (`<os>`, Python `<ver>`)** — 4 cells: `ubuntu-latest × 3.10/3.11/3.12` plus `macos-latest × 3.12`.
+- **`test-project`** → **Project Tests (`<project>`, py`<ver>`)** — 18 cells: each of the 9 public exemplars (`templates/template_*`) on `py3.10` and `py3.12`, ubuntu-latest only.
+
+Require the combinations you care about, or use GitHub rulesets that treat required checks flexibly.
 
 ```yaml
 required_status_checks:
@@ -152,9 +157,12 @@ required_status_checks:
     - "Infra Tests (ubuntu-latest, Python 3.10)"
     - "Infra Tests (ubuntu-latest, Python 3.11)"
     - "Infra Tests (ubuntu-latest, Python 3.12)"
-    - "Project Tests (ubuntu-latest, Python 3.10)"
-    - "Project Tests (ubuntu-latest, Python 3.11)"
-    - "Project Tests (ubuntu-latest, Python 3.12)"
+    - "Infra Tests (macos-latest, Python 3.12)"
+    # test-project expands to 18 checks: "Project Tests (<project>, py<ver>)"
+    # for each templates/template_* exemplar on py3.10 and py3.12. Examples:
+    - "Project Tests (templates/template_active_inference, py3.12)"
+    - "Project Tests (templates/template_code_project, py3.10)"
+    # ... (one check per exemplar × {py3.10, py3.12})
     # Optional: only when fep_lean job runs (skipped if no lean-toolchain file)
     # - "fep_lean (gauss + lake)"
     # Optional (informational artefact only): "Unified Health Report (informational)"

--- a/.github/README.md
+++ b/.github/README.md
@@ -838,8 +838,8 @@ The repo-wide `permissions:` is `contents: read`; every job re-declares its own 
 | 3 | `health` | `lint` | always | Unified health report (informational, non-blocking) |
 | 4 | `verify-no-mocks` | `lint` | always | Enforces the zero-mock policy (`scripts/verify_no_mocks.py`) |
 | 5 | `setup-hook-windows-smoke` | `verify-no-mocks`, `detect` | `needs.detect.outputs.setup_hook == 'true'` | Windows smoke test of `projects/**/scripts/setup_hook.py` |
-| 6 | `test-infra` | `verify-no-mocks` | always | Infra suite, matrix Ubuntu/macOS × Py 3.10–3.12, `--cov-fail-under=60` (macOS leg `continue-on-error`) |
-| 7 | `test-project` | `verify-no-mocks` | always | Per-project suites, same matrix; per-project ≥90 / combined-union ≥75 |
+| 6 | `test-infra` | `verify-no-mocks` | always | Infra suite, matrix Ubuntu × Py 3.10/3.11/3.12 + macOS × Py 3.12 (4 cells), `--cov-fail-under=60` (macOS leg `continue-on-error`) |
+| 7 | `test-project` | `verify-no-mocks` | always | Per-project suites — one parallel ubuntu job per public exemplar × {py3.10, py3.12} (9 × 2 = 18 cells); each enforces that project's own ≥90 floor via `01_run_tests.py --project <name> --project-only --include-slow` |
 | 8 | `fep-lean` | `verify-no-mocks`, `detect` | `needs.detect.outputs.fep_lean == 'true'` | Lean-toolchain project build + tests (`--cov-fail-under=89` rotating exception) |
 | 9 | `validate` | `lint` | always | Manuscript/output validation (`infrastructure.validation.cli`) |
 | 10 | `security` | `lint` | always | Bandit MEDIUM+ (`bandit.yaml`) over `infrastructure/ scripts/ projects/` |
@@ -928,13 +928,17 @@ pre-commit run --hook-stage pre-push --all-files
 
 ### Branch Protection
 
-Set in **Settings → Branches → main**:
+`main` is currently unprotected, so the following is illustrative. Set in **Settings → Branches → main**:
 
 ```text
 Required status checks:
   Lint & Type Check
   Infra Tests (ubuntu-latest, Python 3.10/3.11/3.12)
-  Project Tests (ubuntu-latest, Python 3.10/3.11/3.12)
+  Infra Tests (macos-latest, Python 3.12)
+  # test-project expands to 18 checks: Project Tests (templates/<exemplar>, py3.10|py3.12)
+  # one per public exemplar × {py3.10, py3.12}. Examples:
+  Project Tests (templates/template_active_inference, py3.12)
+  Project Tests (templates/template_code_project, py3.10)
   Validate Manuscripts · Security Scan · Documentation Lint · Performance Check
   # Optional informational artefact: Unified Health Report (informational)
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -50,8 +50,8 @@ flowchart TB
     LINT --> SEC[security]
     LINT --> DL[docs-lint<br/>mermaid + cross-links + consistency<br/>installs mmdc + chrome-headless-shell]
     VNM --> SHW[setup-hook-windows-smoke<br/>skipped if no setup_hook.py]
-    VNM --> TI[test-infra<br/>matrix: ubuntu+macos × 3.10/3.11/3.12<br/>codecov on 3.12/ubuntu only]
-    VNM --> TP[test-project<br/>01_run_tests.py per-project pytest]
+    VNM --> TI[test-infra<br/>matrix: ubuntu × 3.10/3.11/3.12 + macOS × 3.12<br/>codecov on 3.12/ubuntu only]
+    VNM --> TP[test-project<br/>per-project: 9 exemplars × py3.10/py3.12 = 18 ubuntu jobs<br/>01_run_tests.py --project per cell]
     VNM --> FL[fep-lean<br/>ubuntu-only · skipped if no lean-toolchain]
     DET --> SHW
     DET --> FL
@@ -97,7 +97,7 @@ flowchart TB
 
 #### 4. Infrastructure Tests (`test-infra`)
 
-- **Matrix:** `ubuntu-latest`, `macos-latest` × `3.10`, `3.11`, `3.12` (6 combinations)
+- **Matrix:** `ubuntu-latest` × `3.10`, `3.11`, `3.12`, plus an `include:` of `macos-latest` × `3.12` (4 cells). macOS legs are ~10x cost and rarely surface OS-specific breakage beyond the 3.12 cell, so only the 3.12 smoke runs there.
 - **Coverage threshold:** 60% (`--cov-fail-under=60`)
 - **Coverage file:** `.coverage.infra` (isolated from project coverage)
 - **Exclusions:** Tests marked `requires_ollama` are skipped (`-m "not requires_ollama"`)
@@ -106,11 +106,11 @@ flowchart TB
 #### 5. Project Tests (`test-project`)
 
 - **Sync:** `uv sync --group rendering --group monitoring --group discopy` — same packages as a fresh local `uv sync` at the repo root for DisCoPy string-diagram tests: root **`default-groups`** are `dev`, `rendering`, and **`discopy`**, so `uv sync` already installs **DisCoPy**; this job adds **monitoring** (not in `default-groups`). **Hypothesis** comes from the **dev** group (parametric tests), not from `discopy` (see root `pyproject.toml` `[dependency-groups]` and `default-groups`).
-- **Matrix:** Same as `test-infra` (6 combinations)
-- **Coverage threshold:** **75% combined union** (`DEFAULT_FAIL_UNDER` in [`infrastructure/core/test_runner.py`](../../infrastructure/core/test_runner.py)) — enforced via `coverage report` after all projects append into one trace. **Per-project standalone** runs still target **≥ 90%** on each project's own `src/`.
-- **Coverage file:** `.coverage.project` (isolated)
-- **Scope:** [`scripts/01_run_tests.py`](../../scripts/01_run_tests.py) `--project-only --all-projects --public-projects --non-strict --include-slow`, which delegates to [`infrastructure.core.test_runner.run_per_project_pytest`](../../infrastructure/core/test_runner.py) (one pytest process per public project from `infrastructure.project.public_scope`, project subprocesses pin `coverage` to the workspace version before `--cov-append`, then `coverage xml`). Rotating local projects are not part of this public-repo gate; dedicated project jobs own their own toolchains. <!-- noqa: docs-lint -->
-- **Codecov upload:** On Python 3.12 / ubuntu-latest only
+- **Matrix:** **Per-project split** — `runs-on: ubuntu-latest` (no macOS) × `python-version: [3.10, 3.12]` × the **9** public exemplars (`templates/template_*`) = **18 parallel jobs**. Each exemplar runs in its own job, so wall-clock is the slowest single project rather than the sequential sum. py3.10 (floor) + py3.12 (ceiling) give cross-version coverage; macOS breadth is handled by `test-infra`. Job `timeout-minutes: 45`.
+- **Coverage threshold:** Each job enforces **that project's own ≥ 90%** floor on its `src/` (per CLAUDE.md). There is **no longer** a combined-union run or `--cov-append` — every project is isolated in its own job, which also removes the old `code_project`/`fep_lean` conftest plugin-name collision.
+- **Coverage file:** `.coverage.project` (isolated; removed at the start of each job before the run)
+- **Scope:** [`scripts/01_run_tests.py`](../../scripts/01_run_tests.py) `--project <name> --project-only --include-slow` (one invocation per matrix cell), then `coverage xml -o coverage-project.xml`. Rotating local projects are not part of this public-repo gate; dedicated project jobs own their own toolchains.
+- **Codecov upload:** On Python 3.12 only
 
 #### 6. fep_lean — real Open Gauss + Lake (`fep-lean`)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -26,8 +26,8 @@ flowchart TB
     LINT --> SEC[security<br/>pip-audit + bandit -c bandit.yaml]
     LINT --> DL[docs-lint<br/>mermaid + links + consistency]
     VNM --> SHW[setup-hook-windows-smoke<br/>conditional · Windows]
-    VNM --> TI[test-infra<br/>ubuntu+macos × py310–312<br/>≥ 60% coverage]
-    VNM --> TP[test-project<br/>01_run_tests.py public projects<br/>≥ 75% union coverage]
+    VNM --> TI[test-infra<br/>ubuntu × py310–312 + macOS × py312<br/>≥ 60% coverage]
+    VNM --> TP[test-project<br/>9 exemplars × py310/py312 = 18 ubuntu jobs<br/>each ≥ 90% own src/]
     VNM --> FL[fep-lean optional<br/>gauss + lake · timeout 60m]
     TI --> PERF[performance<br/>import time ≤ 5 s]
     TP --> PERF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,22 +369,23 @@ jobs:
       - name: Sync dependencies (dev + optional test groups)
         run: uv sync --group rendering --group monitoring --group discopy
 
+      # 01_run_tests.py --project runs pytest with cwd=<project> and enforces that
+      # project's own --cov-fail-under=90 internally, writing coverage into the
+      # project dir (projects/<name>/.coverage.project + coverage_project.json).
+      # The gate is therefore authoritative here; no repo-root coverage step.
       - name: Run project tests
         env:
-          COVERAGE_FILE: .coverage.project
           PYTHONPATH: .
         run: |
           set -euo pipefail
-          rm -f .coverage.project coverage-project.xml
           uv run python scripts/01_run_tests.py \
             --project "${{ matrix.project }}" --project-only --include-slow
-          uv run coverage xml -o coverage-project.xml
 
       - name: Upload project coverage to Codecov
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
-          files: coverage-project.xml
+          files: projects/${{ matrix.project }}/coverage_project.json
           flags: projects
           name: project-coverage
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,32 +323,37 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Job 4 — Project Tests (matrix: ubuntu + macos × Python 3.10–3.12)
+# Job 4 — Project Tests (one parallel job per public exemplar)
 # ─────────────────────────────────────────────────────────────────────────────
   test-project:
-    name: "Project Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})"
-    runs-on: ${{ matrix.os }}
-    # Sequential per-project pytest across all nine public exemplars with
-    # --include-slow (active_inference Lean + textbook rendering are heavy).
-    # After the gate-artifact caching fix the suite runs ~36-38 min on macOS but
-    # ~45 min on the slower ubuntu runners; at timeout-minutes: 50 the ubuntu legs
-    # had only ~5 min of headroom and ubuntu-3.10 was cancelled right at the 50 min
-    # cap. 70 absorbs ubuntu runner variance for the nine-exemplar matrix.
-    timeout-minutes: 70
+    name: "Project Tests (${{ matrix.project }}, py${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+    # Each public exemplar runs in its OWN parallel job, so wall-clock is the
+    # slowest single project (~active_inference) instead of the ~45 min sequential
+    # sum of all nine. Each job enforces that project's own 90% floor via
+    # ``scripts/01_run_tests.py --project`` (authoritative per CLAUDE.md), which
+    # also removes the old code_project/fep_lean conftest plugin-name collision
+    # (every project is already isolated in its own job). py3.10 (floor) + py3.12
+    # (ceiling) give cross-version coverage; macOS breadth is handled by test-infra.
+    # 45 min is a generous backstop — only active_inference approaches it.
+    timeout-minutes: 45
     needs: [verify-no-mocks]
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu covers all three Python versions; macOS runs only the 3.12
-        # smoke (macOS legs are ~10x cost and rarely surface OS-specific project
-        # breakage beyond what the 3.12 cell catches).
-        os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
-        include:
-          - os: macos-latest
-            python-version: "3.12"
+        python-version: ["3.10", "3.12"]
+        project:
+          - templates/template_active_inference
+          - templates/template_autoresearch_project
+          - templates/template_autoscientists
+          - templates/template_code_project
+          - templates/template_newspaper
+          - templates/template_prose_project
+          - templates/template_sia
+          - templates/template_template
+          - templates/template_textbook
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -364,16 +369,6 @@ jobs:
       - name: Sync dependencies (dev + optional test groups)
         run: uv sync --group rendering --group monitoring --group discopy
 
-      - name: Fix macOS socket.getfqdn timeout
-        if: runner.os == 'macOS'
-        run: sudo scutil --set HostName "$(hostname)"
-
-      # One pytest process per project: template_code_project and fep_lean both use
-      # ``tests/conftest.py``, which registers as the same plugin name if collected
-      # in a single invocation. fep_lean runs in job ``fep-lean`` (real gauss/lake).
-      # The per-project loop, --cov-append accumulation, and combined coverage gate
-      # live in infrastructure.core.test_runner.run_per_project_pytest so CI and
-      # local runs share one implementation.
       - name: Run project tests
         env:
           COVERAGE_FILE: .coverage.project
@@ -382,11 +377,11 @@ jobs:
           set -euo pipefail
           rm -f .coverage.project coverage-project.xml
           uv run python scripts/01_run_tests.py \
-            --project-only --all-projects --public-projects --non-strict --include-slow
+            --project "${{ matrix.project }}" --project-only --include-slow
           uv run coverage xml -o coverage-project.xml
 
       - name: Upload project coverage to Codecov
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: coverage-project.xml


### PR DESCRIPTION
Stacked on #17 (base will retarget to main once #17 merges).

## What
Replace the single sequential 9-exemplar `test-project` job (sum ~45 min on ubuntu) with a **project-axis matrix**: each public exemplar runs in its own parallel ubuntu job at **py3.10 (floor) + py3.12 (ceiling)** = 18 jobs.

## Why
- **Wall-clock** = slowest single project (~active_inference) instead of the sum of all nine.
- **Failure isolation**: a red job names the exact project + Python version immediately.
- **Authoritative gating**: each job runs `scripts/01_run_tests.py --project <name> --project-only --include-slow`, enforcing that project's **own 90% floor** (per CLAUDE.md) — stronger than the old 75% combined-union gate.
- Removes the old `template_code_project`/`fep_lean` conftest plugin-name collision (every project is isolated in its own job).
- macOS breadth stays in `test-infra`; Codecov upload (py3.12) merges per-project coverage by flag.

## Validation
Locally: `scripts/01_run_tests.py --project templates/template_newspaper --project-only --include-slow` → 48/48, 94.1% (≥90%). YAML valid; matrix expands to 18 jobs. `.github` CI-structure docs (AGENTS/README + workflows/AGENTS/README) updated to match the new test-infra (ubuntu×3 + macOS 3.12) and test-project layouts.

This PR is the structural follow-up flagged in #17; its own CI run validates the new matrix before merge.