### PR TITLE
feat(active_inference): Expected Free Energy decomposition (epistemic/pragmatic)

### DIFF
--- a/docs/_generated/canonical_facts.md
+++ b/docs/_generated/canonical_facts.md
@@ -1,6 +1,6 @@
 # Canonical Factsheet
 
-**Generated from live repo state on 2026-06-03 (UTC).** Last measured runs: `generate_active_projects_doc.py`, `generate_architecture_overview.py`, `generate_publication_records_doc.py --refresh-external`, `generate_api_reference_doc.py --write`, `generate_stage_table_doc.py --write`, `infrastructure.skills write`, `infrastructure.skills write-index`, `find infrastructure -name '*.py' -type f | wc -l` (**516**), `pytest tests/infra_tests/project/ --collect-only -q --no-cov` (**214**), publishing suite collection/full run (**381**), exemplar project coverage gates (see Test Status), strict drift + line-count gates (see Thin-orchestrator gates below).
+**Generated from live repo state on 2026-06-03 (UTC).** Last measured runs: `generate_active_projects_doc.py`, `generate_architecture_overview.py`, `generate_publication_records_doc.py --refresh-external`, `generate_api_reference_doc.py --write`, `generate_stage_table_doc.py --write`, `infrastructure.skills write`, `infrastructure.skills write-index`, `find infrastructure -name '*.py' -type f | wc -l` (**518**), `pytest tests/infra_tests/project/ --collect-only -q --no-cov` (**214**), publishing suite collection/full run (**381**), exemplar project coverage gates (see Test Status), strict drift + line-count gates (see Thin-orchestrator gates below).
 
 This file aggregates verifiable facts from discovery scripts, CI configuration, and test execution. Human-written documentation should link here rather than duplicate lists or numbers.
 
@@ -86,7 +86,7 @@ Python modules on disk:
 find infrastructure -name '*.py' -type f | wc -l
 ```
 
-(Last refreshed count: **516** on 2026-06-03 UTC — point-in-time; re-derive with the command above, the literal drifts as the tree changes.)
+(Last refreshed count: **518** on 2026-06-05 UTC — point-in-time; re-derive with the command above, the literal drifts as the tree changes.)
 
 See `infrastructure/AGENTS.md` for module-specific function signatures and entry points.
 

--- a/projects/templates/template_active_inference/src/simulation/efe_decomposition.py
+++ b/projects/templates/template_active_inference/src/simulation/efe_decomposition.py
@@ -1,0 +1,210 @@
+"""Closed-form Expected-Free-Energy (EFE) decomposition on the T-maze model.
+
+Active Inference selects policies by minimising the Expected Free Energy
+
+    G(pi) = sum_tau [ risk_tau + ambiguity_tau ]
+
+which admits the two canonical, *exactly equal* decompositions used throughout the
+literature:
+
+* **risk + ambiguity** -- ``risk`` is the KL divergence of the policy-predicted
+  outcomes ``q(o|pi)`` from the preferred outcomes ``p(o) = softmax(C)`` (the
+  pragmatic deviation), and ``ambiguity`` is the expected entropy of the
+  likelihood ``E_q(s)[ H[p(o|s)] ]`` (outcome uncertainty given the state).
+* **pragmatic + epistemic value** -- ``pragmatic_value = E_q(o)[ ln p(o) ]`` is
+  the expected log-preference (utility), and ``epistemic_value = I(s; o | pi)`` is
+  the mutual information between hidden states and outcomes (expected information
+  gain / salience that drives exploration).
+
+These satisfy the exact algebraic identity (per timestep, hence summed):
+
+    risk + ambiguity + pragmatic_value + epistemic_value == 0
+    <=>  G(pi) == -(pragmatic_value + epistemic_value)
+
+derived from ``risk = -H[q(o)] - pragmatic_value`` and
+``epistemic_value = H[q(o)] - ambiguity``. This module computes every term in
+closed form from the finite T-maze generative model (``A, B, C, D``) -- no
+sampling, no pymdp dependency -- so the outputs are byte-deterministic and the
+identity is machine-checkable to floating-point tolerance, mirroring the
+analytical track's ``decomposition_identity_holds`` (Theorem 5.1).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import product
+from typing import Any, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+ArrayF = NDArray[np.float64]
+
+# Identity / non-negativity tolerance shared with the analytical decomposition track.
+EFE_IDENTITY_ATOL: float = 1e-10
+
+
+@dataclass(frozen=True)
+class EFETerms:
+    """The four EFE terms for a single policy, summed over the horizon.
+
+    ``total`` is the Expected Free Energy itself (``risk + ambiguity``).
+    ``identity_residual`` is ``total + pragmatic_value + epistemic_value`` and is
+    zero (to ``EFE_IDENTITY_ATOL``) whenever the closed form is correct.
+    """
+
+    risk: float
+    ambiguity: float
+    pragmatic_value: float
+    epistemic_value: float
+
+    @property
+    def total(self) -> float:
+        """Expected Free Energy G(pi) = risk + ambiguity."""
+        return self.risk + self.ambiguity
+
+    @property
+    def identity_residual(self) -> float:
+        """``(risk + ambiguity) + pragmatic_value + epistemic_value`` (== 0 when valid)."""
+        return self.total + self.pragmatic_value + self.epistemic_value
+
+    @property
+    def identity_holds(self) -> bool:
+        return abs(self.identity_residual) <= EFE_IDENTITY_ATOL
+
+    def to_dict(self) -> dict[str, float | bool]:
+        return {
+            "risk": self.risk,
+            "ambiguity": self.ambiguity,
+            "pragmatic_value": self.pragmatic_value,
+            "epistemic_value": self.epistemic_value,
+            "total": self.total,
+            "identity_residual": self.identity_residual,
+            "identity_holds": self.identity_holds,
+        }
+
+
+def _as_2d(matrix: Any) -> ArrayF:
+    return cast(ArrayF, np.asarray(matrix, dtype=np.float64))
+
+
+def softmax_preference(c_vector: ArrayF) -> ArrayF:
+    """Preferred-outcome distribution ``p(o) = softmax(C)`` from log-preferences."""
+    c = np.asarray(c_vector, dtype=np.float64).reshape(-1)
+    shifted = c - np.max(c)
+    weights = np.exp(shifted)
+    return cast(ArrayF, weights / weights.sum())
+
+
+def _entropy(distribution: ArrayF) -> float:
+    """Shannon entropy in nats, ignoring zero-probability outcomes."""
+    p = np.asarray(distribution, dtype=np.float64).reshape(-1)
+    nonzero = p[p > 0.0]
+    return float(-np.sum(nonzero * np.log(nonzero)))
+
+
+def _kl_divergence(q: ArrayF, p: ArrayF) -> float:
+    """KL(q || p) in nats; +inf where q has support that p does not."""
+    qa = np.asarray(q, dtype=np.float64).reshape(-1)
+    pa = np.asarray(p, dtype=np.float64).reshape(-1)
+    total = 0.0
+    for qi, pi in zip(qa, pa, strict=True):
+        if qi <= 0.0:
+            continue
+        if pi <= 0.0:
+            return float("inf")
+        total += qi * float(np.log(qi / pi))
+    return total
+
+
+def _first_factor(model: dict[str, Any], key: str) -> ArrayF:
+    value = model[key]
+    if isinstance(value, (list, tuple)):
+        return _as_2d(value[0])
+    return _as_2d(value)
+
+
+def decompose_policy_efe(model: dict[str, Any], policy: Sequence[int]) -> EFETerms:
+    """Closed-form EFE term decomposition for one policy (action sequence).
+
+    Beliefs are propagated deterministically from the prior ``D`` through the
+    transition tensor ``B`` under ``policy``; at each visited timestep the four
+    EFE terms are accumulated. Single hidden-state factor and outcome modality,
+    matching :func:`build_tmaze_generative_model`.
+    """
+    a_matrix = _first_factor(model, "A")  # (n_o, n_s)  P(o | s)
+    b_tensor = np.asarray(model["B"][0] if isinstance(model["B"], (list, tuple)) else model["B"], dtype=np.float64)
+    c_vector = _first_factor(model, "C")  # (n_o, 1)
+    d_vector = _first_factor(model, "D")  # (n_s, 1)
+
+    preference = softmax_preference(c_vector)
+    # Per-state likelihood entropy H[p(o | s)] for every hidden state.
+    state_entropy = np.array([_entropy(a_matrix[:, s]) for s in range(a_matrix.shape[1])], dtype=np.float64)
+
+    state_belief = d_vector.reshape(-1).astype(np.float64)
+    risk = ambiguity = pragmatic = epistemic = 0.0
+
+    for action in policy:
+        predicted_obs = a_matrix @ state_belief  # q(o | pi) at this step
+        ambiguity_step = float(state_belief @ state_entropy)  # E_q(s)[ H[p(o|s)] ]
+        risk += _kl_divergence(predicted_obs, preference)
+        ambiguity += ambiguity_step
+        # pragmatic value = E_q(o)[ ln p(o) ]; ln p(o) is finite (softmax > 0).
+        pragmatic += float(np.sum(predicted_obs * np.log(preference)))
+        # epistemic value = mutual information I(s;o) = H[q(o)] - E_q(s)[H[p(o|s)]].
+        epistemic += _entropy(predicted_obs) - ambiguity_step
+        # Propagate the state belief one step under the chosen action.
+        state_belief = b_tensor[:, :, int(action)] @ state_belief
+
+    return EFETerms(
+        risk=risk,
+        ambiguity=ambiguity,
+        pragmatic_value=pragmatic,
+        epistemic_value=epistemic,
+    )
+
+
+def enumerate_policies(num_actions: int, policy_len: int) -> list[tuple[int, ...]]:
+    """All deterministic action sequences of length ``policy_len``."""
+    return [tuple(seq) for seq in product(range(num_actions), repeat=policy_len)]
+
+
+def decompose_all_policies(model: dict[str, Any]) -> dict[str, Any]:
+    """Decompose every length-``policy_len`` policy and summarise the result.
+
+    Returns a JSON-ready dict with one row per policy plus aggregate fields used
+    by the manuscript / claim ledger: the EFE-minimising policy, whether the
+    risk+ambiguity == -(pragmatic+epistemic) identity holds for all policies, and
+    the maximal identity residual observed.
+    """
+    a_matrix = _first_factor(model, "A")
+    num_actions = int(np.asarray(model["B"][0]).shape[2])
+    policy_len = int(model.get("policy_len", 1))
+    policies = enumerate_policies(num_actions, policy_len)
+
+    rows: list[dict[str, Any]] = []
+    for policy in policies:
+        terms = decompose_policy_efe(model, policy)
+        row: dict[str, Any] = {"policy": list(policy)}
+        row.update(terms.to_dict())
+        rows.append(row)
+
+    totals = [row["total"] for row in rows]
+    best_index = int(np.argmin(totals))
+    max_residual = max(abs(row["identity_residual"]) for row in rows)
+
+    return {
+        "schema": "template_active_inference.efe_decomposition.v1",
+        "num_states": int(a_matrix.shape[1]),
+        "num_obs": int(a_matrix.shape[0]),
+        "num_actions": num_actions,
+        "policy_len": policy_len,
+        "policy_count": len(rows),
+        "rows": rows,
+        "efe_minimizing_policy": list(policies[best_index]),
+        "efe_minimizing_total": float(totals[best_index]),
+        "all_identity_holds": bool(all(row["identity_holds"] for row in rows)),
+        "max_identity_residual": float(max_residual),
+        "identity_atol": EFE_IDENTITY_ATOL,
+    }

--- a/projects/templates/template_active_inference/tests/test_efe_decomposition.py
+++ b/projects/templates/template_active_inference/tests/test_efe_decomposition.py
@@ -1,0 +1,153 @@
+"""Tests for the closed-form Expected-Free-Energy decomposition.
+
+Deterministic, no-mocks numerical checks (fixed generative model) covering the
+risk/ambiguity == -(pragmatic+epistemic) identity, term non-negativity, and the
+edge behaviour of the entropy/KL/softmax helpers.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from simulation.efe_decomposition import (
+    EFE_IDENTITY_ATOL,
+    EFETerms,
+    _entropy,
+    _kl_divergence,
+    decompose_all_policies,
+    decompose_policy_efe,
+    enumerate_policies,
+    softmax_preference,
+)
+from simulation.tmaze_model import TMazeSpec, build_tmaze_generative_model
+
+
+def test_softmax_preference_normalizes_and_orders() -> None:
+    p = softmax_preference(np.array([[0.0], [2.0]]))
+    assert abs(float(p.sum()) - 1.0) < 1e-12
+    # Higher log-preference -> higher probability mass.
+    assert p[1] > p[0]
+    expected_hi = math.exp(2.0) / (math.exp(0.0) + math.exp(2.0))
+    assert abs(float(p[1]) - expected_hi) < 1e-12
+
+
+def test_softmax_preference_uniform_when_flat() -> None:
+    p = softmax_preference(np.array([5.0, 5.0, 5.0]))
+    assert np.allclose(p, np.full(3, 1.0 / 3.0), atol=1e-12)
+
+
+def test_entropy_one_hot_is_zero_and_uniform_is_log_n() -> None:
+    assert _entropy(np.array([1.0, 0.0, 0.0])) == 0.0
+    assert abs(_entropy(np.array([0.5, 0.5])) - math.log(2.0)) < 1e-12
+    assert abs(_entropy(np.full(4, 0.25)) - math.log(4.0)) < 1e-12
+
+
+def test_kl_divergence_identical_is_zero_and_disjoint_is_inf() -> None:
+    q = np.array([0.3, 0.7])
+    assert abs(_kl_divergence(q, q)) < 1e-12
+    # q places mass where p has none -> infinite divergence.
+    assert _kl_divergence(np.array([0.5, 0.5]), np.array([1.0, 0.0])) == float("inf")
+    # q with a zero component is skipped (0 * log 0 == 0), stays finite.
+    assert math.isfinite(_kl_divergence(np.array([0.0, 1.0]), np.array([0.5, 0.5])))
+
+
+def test_enumerate_policies_count_and_shape() -> None:
+    policies = enumerate_policies(num_actions=2, policy_len=3)
+    assert len(policies) == 2**3
+    assert all(len(p) == 3 for p in policies)
+    assert len(set(policies)) == len(policies)  # all distinct
+
+
+def test_efeterms_total_identity_and_dict() -> None:
+    terms = EFETerms(risk=1.0, ambiguity=0.5, pragmatic_value=-1.2, epistemic_value=-0.3)
+    assert abs(terms.total - 1.5) < 1e-12
+    assert abs(terms.identity_residual - 0.0) < 1e-12
+    assert terms.identity_holds is True
+    payload = terms.to_dict()
+    assert payload["total"] == terms.total
+    assert payload["identity_holds"] is True
+    # A broken set of terms must report the identity as violated.
+    broken = EFETerms(risk=1.0, ambiguity=0.0, pragmatic_value=0.0, epistemic_value=0.0)
+    assert broken.identity_holds is False
+
+
+def test_decompose_policy_efe_identity_holds() -> None:
+    model = build_tmaze_generative_model()
+    for policy in enumerate_policies(2, model["policy_len"]):
+        terms = decompose_policy_efe(model, policy)
+        # The exact algebraic identity: G == -(pragmatic + epistemic).
+        assert abs(terms.identity_residual) <= EFE_IDENTITY_ATOL
+        # Risk (a KL) and ambiguity (an expected entropy) are non-negative.
+        assert terms.risk >= -EFE_IDENTITY_ATOL
+        assert terms.ambiguity >= -EFE_IDENTITY_ATOL
+
+
+def test_deterministic_likelihood_has_zero_ambiguity() -> None:
+    # A perfectly informative likelihood (diag == 1.0) carries no ambiguity, so
+    # the epistemic value reduces to the entropy of the predicted outcomes.
+    model = build_tmaze_generative_model(TMazeSpec(likelihood_diag=1.0))
+    terms = decompose_policy_efe(model, (0, 0))
+    assert abs(terms.ambiguity) < 1e-12
+    assert terms.epistemic_value >= -1e-12
+
+
+def test_decompose_all_policies_structure_and_identity() -> None:
+    model = build_tmaze_generative_model()
+    result = decompose_all_policies(model)
+    assert result["schema"] == "template_active_inference.efe_decomposition.v1"
+    assert result["policy_count"] == 2 ** model["policy_len"]
+    assert len(result["rows"]) == result["policy_count"]
+    assert result["all_identity_holds"] is True
+    assert result["max_identity_residual"] <= EFE_IDENTITY_ATOL
+    # Each row exposes the four terms plus the derived fields.
+    row = result["rows"][0]
+    for key in ("policy", "risk", "ambiguity", "pragmatic_value", "epistemic_value", "total"):
+        assert key in row
+    # The reported minimiser really is the argmin over totals.
+    totals = [r["total"] for r in result["rows"]]
+    assert abs(result["efe_minimizing_total"] - min(totals)) < 1e-12
+
+
+def test_efe_minimizing_policy_moves_toward_goal() -> None:
+    # The T-maze rewards reaching the goal observation; the EFE-minimising policy
+    # must take the goal-seeking action first (action 0: state 0 -> state 1).
+    model = build_tmaze_generative_model()
+    result = decompose_all_policies(model)
+    assert result["efe_minimizing_policy"][0] == 0
+
+
+def test_decompose_is_byte_deterministic() -> None:
+    model = build_tmaze_generative_model()
+    first = decompose_all_policies(model)
+    second = decompose_all_policies(build_tmaze_generative_model())
+    assert first == second
+
+
+def test_pragmatic_value_prefers_goal_observation() -> None:
+    # Pragmatic value is the expected log-preference; a policy whose predicted
+    # outcomes concentrate on the preferred goal observation must score higher
+    # pragmatic value than one that stays at the (non-preferred) start.
+    model = build_tmaze_generative_model()
+    go = decompose_policy_efe(model, (0, 0))  # moves to goal state
+    stay = decompose_policy_efe(model, (1, 1))  # stays at start
+    assert go.pragmatic_value > stay.pragmatic_value
+
+
+def test_first_factor_accepts_bare_array() -> None:
+    # decompose helpers must tolerate a non-listed C/D (defensive _first_factor).
+    model = build_tmaze_generative_model()
+    model_bare = dict(model)
+    model_bare["C"] = np.asarray(model["C"][0])
+    model_bare["D"] = np.asarray(model["D"][0])
+    terms = decompose_policy_efe(model_bare, (0, 1))
+    assert abs(terms.identity_residual) <= EFE_IDENTITY_ATOL
+
+
+@pytest.mark.parametrize("diag", [0.6, 0.75, 0.9, 0.99])
+def test_identity_robust_across_likelihoods(diag: float) -> None:
+    model = build_tmaze_generative_model(TMazeSpec(likelihood_diag=diag))
+    result = decompose_all_policies(model)
+    assert result["all_identity_holds"] is True


### PR DESCRIPTION
Adds the single most defining Active Inference quantity the template was missing — and which `15_discussion_outlook.md` explicitly flags as deferred ("extending to full expected-free-energy policy selection is documented as a follow-on track"). Identified as the #1 addition by all three agents of a survey of the exemplar.

## Layer 1 (this commit): the scientific core
`src/simulation/efe_decomposition.py` computes, in closed form on the finite T-maze generative model (A,B,C,D), both canonical EFE decompositions and their **exact algebraic identity**:

- `G(π) = risk + ambiguity` — risk = `KL[q(o|π) ‖ softmax(C)]` (pragmatic deviation), ambiguity = `E_q(s)[H[p(o|s)]]` (outcome uncertainty)
- `= −(pragmatic_value + epistemic_value)` — pragmatic = `E_q(o)[ln p(o)]` (utility), epistemic = `I(s;o|π)` (mutual-information info-gain / salience)
- machine-checked: `risk + ambiguity + pragmatic + epistemic ≡ 0` to 1e-10, mirroring the analytical track's `decomposition_identity_holds` (Theorem 5.1).

Closed-form, no sampling, byte-deterministic. **17 deterministic no-mocks tests, 100% module coverage.** Full active_inference suite **286/287, 92.1%** (maintained); ruff/mypy/format clean. The EFE-minimizing policy correctly seeks the goal; the identity holds across all policies and likelihood settings.

## Planned follow-on layers (same PR or follow-up)
Producer → `output/data/efe_decomposition.json` (byte-deterministic) → EFE risk/ambiguity bar figure → Methods/Results section with hydrated tokens → claim-ledger + sheaf-track binding, each gated on the full suite + render.