### PR TITLE
feat(active_inference): Expected Free Energy decomposition figure

### DIFF
--- a/projects/templates/template_active_inference/figures.yaml
+++ b/projects/templates/template_active_inference/figures.yaml
@@ -21,6 +21,25 @@ palette:
   header_bg: "#e2e8f0"
 
 figures:
+  efe_decomposition:
+    filename: efe_decomposition.png
+    alt: >-
+      Two-panel bar chart of the Expected Free Energy term decomposition across the
+      four length-two T-maze policies (action sequences 00, 01, 10, 11). The left
+      panel stacks risk (pragmatic deviation, the KL of policy-predicted outcomes
+      from preferences) below ambiguity (epistemic, the expected likelihood entropy)
+      so each bar's height is the Expected Free Energy G(pi); the goal-seeking policy
+      with minimum G is marked. The right panel shows the equal-and-opposite
+      pragmatic value (expected log-preference) and epistemic value (state-outcome
+      mutual information) per policy, with a zero reference line, illustrating the
+      exact identity G(pi) = -(pragmatic + epistemic).
+    caption: >-
+      Closed-form Expected Free Energy decomposition over the finite T-maze policies.
+      Left: $G(\pi)$ = risk + ambiguity (stacked), with the goal-seeking minimiser
+      marked. Right: the pragmatic and epistemic values, which sum to $-G(\pi)$.
+      Both forms are computed in closed form (no sampling) and satisfy
+      risk + ambiguity + pragmatic + epistemic = 0 to machine precision.
+    width: 0.95
   ising_mi_curve:
     filename: ising_mi_curve.png
     alt: >-

--- a/projects/templates/template_active_inference/src/gates/artifact_manifest.py
+++ b/projects/templates/template_active_inference/src/gates/artifact_manifest.py
@@ -7,6 +7,7 @@ REQUIRED_OUTPUTS: tuple[str, ...] = (
     "output/data/si_tmaze_summary.json",
     "output/data/si_tmaze_trace.json",
     "output/data/analysis_statistics.json",
+    "output/figures/efe_decomposition.png",
     "output/figures/ising_mi_curve.png",
     "output/figures/free_energy_curve.png",
     "output/figures/si_tmaze_actions.png",

--- a/projects/templates/template_active_inference/src/roadmap_tracks/integration_audit.py
+++ b/projects/templates/template_active_inference/src/roadmap_tracks/integration_audit.py
@@ -473,6 +473,7 @@ def build_figure_source_map(project_root: Path) -> dict[str, Any]:
     from visualizations.figure_registry import load_figure_registry
 
     sources = {
+        "efe_decomposition": ["src/simulation/efe_decomposition.py", "src/simulation/tmaze_model.py"],
         "ising_mi_curve": ["output/data/parameter_sweep.csv"],
         "free_energy_curve": ["src/analytical/decomposition.py"],
         "si_belief_entropy_curve": ["output/data/si_tmaze_trace.json"],

--- a/projects/templates/template_active_inference/src/visualizations/figures.py
+++ b/projects/templates/template_active_inference/src/visualizations/figures.py
@@ -415,7 +415,70 @@ def figure_scholarship_source_map(project_root: Path) -> Path:
     return out
 
 
+def figure_efe_decomposition(project_root: Path) -> Path:
+    """Expected Free Energy term decomposition across T-maze policies.
+
+    Left panel: ``G(pi) = risk + ambiguity`` as a stacked bar per policy, with the
+    EFE-minimising policy marked. Right panel: the equal-and-opposite
+    ``G(pi) = -(pragmatic_value + epistemic_value)`` decomposition. Computed in
+    closed form (no sampling) so the figure is byte-deterministic.
+    """
+    from simulation.efe_decomposition import decompose_all_policies
+    from simulation.tmaze_model import build_tmaze_generative_model
+
+    root = project_root.resolve()
+    style = load_figure_style(root)
+    result = decompose_all_policies(build_tmaze_generative_model())
+    rows = result["rows"]
+    labels = ["".join(str(a) for a in row["policy"]) for row in rows]
+    risk = [float(row["risk"]) for row in rows]
+    ambiguity = [float(row["ambiguity"]) for row in rows]
+    pragmatic = [float(row["pragmatic_value"]) for row in rows]
+    epistemic = [float(row["epistemic_value"]) for row in rows]
+    totals = [r + a for r, a in zip(risk, ambiguity)]
+    best_label = "".join(str(a) for a in result["efe_minimizing_policy"])
+    best_idx = labels.index(best_label)
+    x = np.arange(len(labels))
+
+    out = figure_output_path(root, "efe_decomposition")
+    with apply_style(style):
+        fig, (ax_g, ax_pe) = plt.subplots(1, 2, figsize=(9.5, 4))
+        ax_g.bar(x, risk, color=style.color("secondary"), label="risk (pragmatic deviation)")
+        ax_g.bar(x, ambiguity, bottom=risk, color=style.color("accent"), label="ambiguity (epistemic)")
+        ax_g.scatter(
+            [x[best_idx]],
+            [totals[best_idx]],
+            color=style.color("fail"),
+            zorder=3,
+            s=45,
+            label=f"min G at policy {best_label}",
+        )
+        ax_g.set_xticks(x)
+        ax_g.set_xticklabels(labels)
+        ax_g.set_xlabel("Policy (action sequence)")
+        ax_g.set_ylabel("Expected free energy (nats)")
+        ax_g.set_title(r"$G(\pi)$ = risk + ambiguity")
+        style_grid(ax_g, style)
+        ax_g.legend(frameon=False, fontsize=7)
+
+        width = 0.4
+        ax_pe.bar(x - width / 2, pragmatic, width, color=style.color("primary"), label="pragmatic value")
+        ax_pe.bar(x + width / 2, epistemic, width, color=style.color("muted"), label="epistemic value")
+        ax_pe.axhline(0.0, color=style.color("reference"), linewidth=0.8)
+        ax_pe.set_xticks(x)
+        ax_pe.set_xticklabels(labels)
+        ax_pe.set_xlabel("Policy (action sequence)")
+        ax_pe.set_ylabel("Value (nats)")
+        ax_pe.set_title(r"$G(\pi)$ = -(pragmatic + epistemic)")
+        style_grid(ax_pe, style)
+        ax_pe.legend(frameon=False, fontsize=7)
+
+        save_styled_figure(fig, out, style)
+    return out
+
+
 FIGURE_GENERATORS: dict[str, Callable[[Path], Path | None]] = {
+    "efe_decomposition": figure_efe_decomposition,
     "ising_mi_curve": figure_ising_mi_curve,
     "free_energy_curve": figure_free_energy_curve,
     "si_belief_entropy_curve": figure_si_belief_entropy_curve,


### PR DESCRIPTION
Layer 2 of the EFE addition (follows #19, which landed the closed-form decomposition). Adds `figure_efe_decomposition` — a two-panel byte-deterministic chart: left stacks `G(π)=risk+ambiguity` per T-maze policy (goal-seeking minimiser marked); right shows the equal-and-opposite pragmatic/epistemic split. Registered across all four figure contracts (FIGURE_GENERATORS, figures.yaml alt+caption, REQUIRED_OUTPUTS, figure_source_map provenance). Figure tests 12/12; full active_inference suite 286/287 at 90.3% (≥90% gate); ruff/mypy clean.