### PR TITLE
fix(active_inference): harden sheaf integrity gates (RedTeam verifier-first)

### DIFF
--- a/projects/templates/template_active_inference/src/gates/artifact_manifest.py
+++ b/projects/templates/template_active_inference/src/gates/artifact_manifest.py
@@ -152,4 +152,5 @@ REQUIRED_OUTPUT_CHECK_KEYS: tuple[str, ...] = (
     "output/reports/scope_boundary_audit.json",
     "output/data/animation_frame_deltas.json",
     "output/reports/manuscript_staleness_report.json",
+    "figures_nonblank",
 )

--- a/projects/templates/template_active_inference/src/gates/output_checks.py
+++ b/projects/templates/template_active_inference/src/gates/output_checks.py
@@ -7,6 +7,34 @@ from pathlib import Path
 
 from gates.artifact_manifest import REQUIRED_OUTPUTS
 
+# Matches the tests/test_figures.py::_assert_png lower bound. A 0-byte or blank
+# PNG has the empty-file sha (e3b0c4...) yet still satisfies Path.exists(); a
+# size floor plus a PIL decode of width/height closes that fail-open hole.
+_MIN_FIGURE_BYTES = 5_000
+
+
+def _figures_nonblank(root: Path) -> bool:
+    """Return True only if every required figure PNG is non-trivially sized and decodable."""
+    from PIL import Image
+
+    png_rels = [rel for rel in REQUIRED_OUTPUTS if rel.startswith("output/figures/") and rel.endswith(".png")]
+    if not png_rels:
+        return False
+    for rel in png_rels:
+        path = root / rel
+        if not path.is_file():
+            return False
+        if path.stat().st_size < _MIN_FIGURE_BYTES:
+            return False
+        try:
+            with Image.open(path) as img:
+                width, height = img.size
+        except (OSError, ValueError):
+            return False
+        if width <= 0 or height <= 0:
+            return False
+    return True
+
 
 def _read_json(path: Path) -> dict:
     if not path.exists():
@@ -41,6 +69,8 @@ def validate_outputs(project_root: Path) -> dict[str, bool]:
     root = project_root.resolve()
     required = [root / rel for rel in REQUIRED_OUTPUTS]
     checks = {str(p.relative_to(root)): p.exists() for p in required}
+
+    checks["figures_nonblank"] = _figures_nonblank(root)
 
     summary_path = root / "output" / "data" / "si_tmaze_summary.json"
     trace_path = root / "output" / "data" / "si_tmaze_trace.json"
@@ -464,6 +494,7 @@ def validate_outputs(project_root: Path) -> dict[str, bool]:
     checks["experiment_plan_metrics"] = checks["experiment_plan_metrics"] and all(
         checks.get(key, False)
         for key in (
+            "figures_nonblank",
             "toy_sweep_track_schemas",
             "formal_interop_track_schemas",
             "integration_audit_track_schemas",

--- a/projects/templates/template_active_inference/src/roadmap_tracks/figure_provenance.py
+++ b/projects/templates/template_active_inference/src/roadmap_tracks/figure_provenance.py
@@ -1,0 +1,104 @@
+"""Figure source-provenance map for canonical sheaf-track gates.
+
+Extracted from ``integration_audit.py`` to keep that module within the
+composability line-count budget. ``mapped`` is re-derived from the filesystem
+(verifier-first) rather than trusting a hardcoded flag: a figure is mapped only
+when it has at least one source and every listed source-code path exists.
+``output/**`` artifact paths are deferred (produced later in the pipeline).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def _is_deferred_source(rel: str) -> bool:
+    """Pipeline-produced artifacts that do not exist at map-build time.
+
+    output/** paths (data, reports, figures) are generated later in the pipeline, so
+    requiring them on a clean tree would falsely report unmapped figures. They are
+    deferred — their existence is verified by the freshness/stale-artifact validators.
+    """
+    normalized = rel.replace("\\", "/").lstrip("./")
+    return normalized.startswith("output/")
+
+
+def _source_path_exists(root: Path, rel: str) -> bool:
+    """A listed source-code path must resolve to a real file or directory on disk."""
+    return (root / rel).exists()
+
+
+def _figure_sources_mapped(root: Path, figure_sources: list[str]) -> bool:
+    """Re-derive `mapped` from the filesystem rather than trusting the hardcoded dict.
+
+    A figure is mapped only when it has at least one source AND every listed
+    source-code path (src/**, *.yaml, *.bib, lean/**, gnn/**, manuscript/**, etc.)
+    exists. output/** artifact paths are deferred (produced later in the pipeline).
+    """
+    if not figure_sources:
+        return False
+    for rel in figure_sources:
+        if _is_deferred_source(rel):
+            continue
+        if not _source_path_exists(root, rel):
+            return False
+    return True
+
+
+def build_figure_source_map(project_root: Path) -> dict[str, Any]:
+    root = project_root.resolve()
+    from visualizations.figure_registry import load_figure_registry
+
+    sources = {
+        "efe_decomposition": ["src/simulation/efe_decomposition.py", "src/simulation/tmaze_model.py"],
+        "precision_sweep": ["src/simulation/precision_sweep.py", "src/simulation/efe_decomposition.py"],
+        "cue_tmaze_advantage": ["src/simulation/cue_tmaze_model.py", "src/simulation/efe_decomposition.py"],
+        "dirichlet_convergence": ["src/simulation/dirichlet_learning.py", "src/simulation/tmaze_model.py"],
+        "ising_mi_curve": ["output/data/parameter_sweep.csv"],
+        "free_energy_curve": ["src/analytical/decomposition.py"],
+        "si_belief_entropy_curve": ["output/data/si_tmaze_trace.json"],
+        "si_obs_action_trace": ["output/data/si_tmaze_summary.json"],
+        "si_tmaze_actions": ["output/data/si_tmaze_summary.json"],
+        "sheaf_layers_overview": ["output/data/sheaf_coverage_matrix.json"],
+        "sheaf_coverage_heatmap": ["output/data/sheaf_coverage_matrix.json"],
+        "invariant_dashboard": ["output/reports/invariants.json"],
+        "tmaze_schematic": [
+            "pymdp.yaml",
+            "output/reports/pymdp_runtime_diagnostics.json",
+            "output/data/pymdp_policy_posterior_grid.json",
+        ],
+        "multi_track_architecture": ["tracks.yaml", "manuscript/sheaf/tracks.yaml"],
+        "lean_boundary_status": ["lean/TemplateActiveInference"],
+        "gnn_ontology_concordance": ["gnn", "manuscript/sections/imrad"],
+        "semantic_gluing_graph": [
+            "output/data/validation_dependency_graph.json",
+            "output/data/sheaf_gluing_certificate.json",
+            "output/data/evidence_field_index.json",
+        ],
+        "theorem_traceability_graph": [
+            "output/data/theorem_traceability_matrix.json",
+            "output/data/proof_dependency_graph.json",
+        ],
+        "causal_ablation_heatmap": [
+            "output/data/causal_ablation_matrix.json",
+            "output/reports/ablation_sensitivity_report.json",
+        ],
+        "scholarship_source_map": ["output/data/scholarship_source_matrix.json", "manuscript/references.bib"],
+    }
+    rows = []
+    for figure_id in sorted(load_figure_registry(root)):
+        figure_sources = sources.get(figure_id, [])
+        rows.append(
+            {
+                "figure_id": figure_id,
+                "sources": figure_sources,
+                "mapped": _figure_sources_mapped(root, figure_sources),
+            }
+        )
+    return {
+        "schema": "template_active_inference.figure_source_map.v1",
+        "rows": rows,
+        "figure_count": len(rows),
+        "all_figures_mapped": bool(rows) and all(row["mapped"] for row in rows),
+    }

--- a/projects/templates/template_active_inference/src/roadmap_tracks/integration_audit.py
+++ b/projects/templates/template_active_inference/src/roadmap_tracks/integration_audit.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import yaml
 
+from roadmap_tracks.figure_provenance import _figure_sources_mapped, build_figure_source_map
+
 TOKEN_RE = re.compile(r"\{\{([a-z][a-z0-9_]*)(?::\.[0-9]+f)?\}\}")
 TOKEN_MATCH_RE = re.compile(r"\{\{([a-z][a-z0-9_]*)(?::\.(\d+)f)?\}\}")
 SELF_PRODUCER = "generate_integration_audit.py"
@@ -36,39 +38,6 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
-
-
-def _is_deferred_source(rel: str) -> bool:
-    """Pipeline-produced artifacts that do not exist at map-build time.
-
-    output/** paths (data, reports, figures) are generated later in the pipeline, so
-    requiring them on a clean tree would falsely report unmapped figures. They are
-    deferred — their existence is verified by the freshness/stale-artifact validators.
-    """
-    normalized = rel.replace("\\", "/").lstrip("./")
-    return normalized.startswith("output/")
-
-
-def _source_path_exists(root: Path, rel: str) -> bool:
-    """A listed source-code path must resolve to a real file or directory on disk."""
-    return (root / rel).exists()
-
-
-def _figure_sources_mapped(root: Path, figure_sources: list[str]) -> bool:
-    """Re-derive `mapped` from the filesystem rather than trusting the hardcoded dict.
-
-    A figure is mapped only when it has at least one source AND every listed
-    source-code path (src/**, *.yaml, *.bib, lean/**, gnn/**, manuscript/**, etc.)
-    exists. output/** artifact paths are deferred (produced later in the pipeline).
-    """
-    if not figure_sources:
-        return False
-    for rel in figure_sources:
-        if _is_deferred_source(rel):
-            continue
-        if not _source_path_exists(root, rel):
-            return False
-    return True
 
 
 def _analysis_scripts(root: Path) -> list[str]:
@@ -498,64 +467,6 @@ def build_release_notes_evidence(project_root: Path) -> dict[str, Any]:
         "rows": rows,
         "row_count": len(rows),
         "all_notes_source_backed": all(row["source"] and row["passed"] for row in rows),
-    }
-
-
-def build_figure_source_map(project_root: Path) -> dict[str, Any]:
-    root = project_root.resolve()
-    from visualizations.figure_registry import load_figure_registry
-
-    sources = {
-        "efe_decomposition": ["src/simulation/efe_decomposition.py", "src/simulation/tmaze_model.py"],
-        "precision_sweep": ["src/simulation/precision_sweep.py", "src/simulation/efe_decomposition.py"],
-        "cue_tmaze_advantage": ["src/simulation/cue_tmaze_model.py", "src/simulation/efe_decomposition.py"],
-        "dirichlet_convergence": ["src/simulation/dirichlet_learning.py", "src/simulation/tmaze_model.py"],
-        "ising_mi_curve": ["output/data/parameter_sweep.csv"],
-        "free_energy_curve": ["src/analytical/decomposition.py"],
-        "si_belief_entropy_curve": ["output/data/si_tmaze_trace.json"],
-        "si_obs_action_trace": ["output/data/si_tmaze_summary.json"],
-        "si_tmaze_actions": ["output/data/si_tmaze_summary.json"],
-        "sheaf_layers_overview": ["output/data/sheaf_coverage_matrix.json"],
-        "sheaf_coverage_heatmap": ["output/data/sheaf_coverage_matrix.json"],
-        "invariant_dashboard": ["output/reports/invariants.json"],
-        "tmaze_schematic": [
-            "pymdp.yaml",
-            "output/reports/pymdp_runtime_diagnostics.json",
-            "output/data/pymdp_policy_posterior_grid.json",
-        ],
-        "multi_track_architecture": ["tracks.yaml", "manuscript/sheaf/tracks.yaml"],
-        "lean_boundary_status": ["lean/TemplateActiveInference"],
-        "gnn_ontology_concordance": ["gnn", "manuscript/sections/imrad"],
-        "semantic_gluing_graph": [
-            "output/data/validation_dependency_graph.json",
-            "output/data/sheaf_gluing_certificate.json",
-            "output/data/evidence_field_index.json",
-        ],
-        "theorem_traceability_graph": [
-            "output/data/theorem_traceability_matrix.json",
-            "output/data/proof_dependency_graph.json",
-        ],
-        "causal_ablation_heatmap": [
-            "output/data/causal_ablation_matrix.json",
-            "output/reports/ablation_sensitivity_report.json",
-        ],
-        "scholarship_source_map": ["output/data/scholarship_source_matrix.json", "manuscript/references.bib"],
-    }
-    rows = []
-    for figure_id in sorted(load_figure_registry(root)):
-        figure_sources = sources.get(figure_id, [])
-        rows.append(
-            {
-                "figure_id": figure_id,
-                "sources": figure_sources,
-                "mapped": _figure_sources_mapped(root, figure_sources),
-            }
-        )
-    return {
-        "schema": "template_active_inference.figure_source_map.v1",
-        "rows": rows,
-        "figure_count": len(rows),
-        "all_figures_mapped": bool(rows) and all(row["mapped"] for row in rows),
     }
 
 

--- a/projects/templates/template_active_inference/src/roadmap_tracks/integration_audit.py
+++ b/projects/templates/template_active_inference/src/roadmap_tracks/integration_audit.py
@@ -38,6 +38,39 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _is_deferred_source(rel: str) -> bool:
+    """Pipeline-produced artifacts that do not exist at map-build time.
+
+    output/** paths (data, reports, figures) are generated later in the pipeline, so
+    requiring them on a clean tree would falsely report unmapped figures. They are
+    deferred — their existence is verified by the freshness/stale-artifact validators.
+    """
+    normalized = rel.replace("\\", "/").lstrip("./")
+    return normalized.startswith("output/")
+
+
+def _source_path_exists(root: Path, rel: str) -> bool:
+    """A listed source-code path must resolve to a real file or directory on disk."""
+    return (root / rel).exists()
+
+
+def _figure_sources_mapped(root: Path, figure_sources: list[str]) -> bool:
+    """Re-derive `mapped` from the filesystem rather than trusting the hardcoded dict.
+
+    A figure is mapped only when it has at least one source AND every listed
+    source-code path (src/**, *.yaml, *.bib, lean/**, gnn/**, manuscript/**, etc.)
+    exists. output/** artifact paths are deferred (produced later in the pipeline).
+    """
+    if not figure_sources:
+        return False
+    for rel in figure_sources:
+        if _is_deferred_source(rel):
+            continue
+        if not _source_path_exists(root, rel):
+            return False
+    return True
+
+
 def _analysis_scripts(root: Path) -> list[str]:
     data = yaml.safe_load((root / "manuscript" / "config.yaml").read_text(encoding="utf-8")) or {}
     return [str(script) for script in ((data.get("analysis") or {}).get("scripts") or [])]
@@ -510,14 +543,19 @@ def build_figure_source_map(project_root: Path) -> dict[str, Any]:
     }
     rows = []
     for figure_id in sorted(load_figure_registry(root)):
+        figure_sources = sources.get(figure_id, [])
         rows.append(
-            {"figure_id": figure_id, "sources": sources.get(figure_id, []), "mapped": bool(sources.get(figure_id))}
+            {
+                "figure_id": figure_id,
+                "sources": figure_sources,
+                "mapped": _figure_sources_mapped(root, figure_sources),
+            }
         )
     return {
         "schema": "template_active_inference.figure_source_map.v1",
         "rows": rows,
         "figure_count": len(rows),
-        "all_figures_mapped": all(row["mapped"] for row in rows),
+        "all_figures_mapped": bool(rows) and all(row["mapped"] for row in rows),
     }
 
 
@@ -877,7 +915,12 @@ def validate_integration_audit_artifacts(project_root: Path) -> list[str]:
     if tokens.get("all_tokens_mapped") is not True or tokens.get("all_tokens_mapped") != tokens_derived:
         issues.append("manuscript_token_provenance.json has unmapped tokens")
     figures = _load_json(root / "output" / "data" / "figure_source_map.json")
-    figures_derived = bool(figures.get("rows")) and all(row.get("mapped") for row in figures.get("rows") or [])
+    # Re-derive from the filesystem: recompute mapped per row from the listed source
+    # paths (source-code paths must exist; output/** is deferred). A stored mapped:true
+    # for a row whose source-code path is missing fails closed here.
+    figures_derived = bool(figures.get("rows")) and all(
+        _figure_sources_mapped(root, list(row.get("sources") or [])) for row in figures.get("rows") or []
+    )
     if figures.get("all_figures_mapped") is not True or figures.get("all_figures_mapped") != figures_derived:
         issues.append("figure_source_map.json has unmapped figures")
     claim_audit = _load_json(root / "output" / "reports" / "claim_evidence_audit.json")
@@ -887,7 +930,11 @@ def validate_integration_audit_artifacts(project_root: Path) -> list[str]:
     if claim_audit.get("all_claims_typed") is not True or claim_audit.get("all_claims_typed") != claims_derived:
         issues.append("claim_evidence_audit.json has untyped claims")
     scope = _load_json(root / "output" / "reports" / "scope_boundary_audit.json")
-    if scope.get("all_current_claims_toy") is not True:
+    scope_rows = scope.get("rows") or []
+    scope_derived = all(row.get("ok") for row in scope_rows)
+    if scope.get("all_current_claims_toy") is not True or scope.get("all_current_claims_toy") != scope_derived:
+        # Re-derived from rows: a row with ok:False fails closed even if the stored
+        # all_current_claims_toy bit was left true.
         issues.append("scope_boundary_audit.json records empirical scope leakage")
     adversarial = _load_json(root / "output" / "reports" / "adversarial_audit.json")
     if adversarial.get("all_expected_failures_documented") is not True:
@@ -933,7 +980,11 @@ def validate_integration_audit_artifacts(project_root: Path) -> list[str]:
     diffoscope = _load_json(root / "output" / "reports" / "artifact_diffoscope.json")
     if diffoscope.get("schema") != "template_active_inference.artifact_diffoscope.v1":
         issues.append("artifact_diffoscope.json schema mismatch")
-    if diffoscope.get("all_equal") is not True:
+    diffoscope_rows = diffoscope.get("rows") or []
+    diffoscope_derived = bool(diffoscope_rows) and all(row.get("equal") for row in diffoscope_rows)
+    if diffoscope.get("all_equal") is not True or diffoscope.get("all_equal") != diffoscope_derived:
+        # Re-derived from rows: a row with equal:False fails closed even if the stored
+        # all_equal bit was left true.
         issues.append("artifact_diffoscope.json records artifact drift")
     license_audit = _load_json(root / "output" / "reports" / "artifact_license_audit.json")
     if license_audit.get("schema") != "template_active_inference.artifact_license_audit.v1":
@@ -943,6 +994,15 @@ def validate_integration_audit_artifacts(project_root: Path) -> list[str]:
     release_notes = _load_json(root / "output" / "reports" / "release_notes_evidence.json")
     if release_notes.get("schema") != "template_active_inference.release_notes_evidence.v1":
         issues.append("release_notes_evidence.json schema mismatch")
-    if release_notes.get("all_notes_source_backed") is not True:
+    release_notes_rows = release_notes.get("rows") or []
+    release_notes_derived = bool(release_notes_rows) and all(
+        row.get("source") and row.get("passed") for row in release_notes_rows
+    )
+    if (
+        release_notes.get("all_notes_source_backed") is not True
+        or release_notes.get("all_notes_source_backed") != release_notes_derived
+    ):
+        # Re-derived from rows: a note missing its source or failing its check fails
+        # closed even if the stored all_notes_source_backed bit was left true.
         issues.append("release_notes_evidence.json has unsupported notes")
     return issues

--- a/projects/templates/template_active_inference/src/roadmap_tracks/sheaf_track_validation.py
+++ b/projects/templates/template_active_inference/src/roadmap_tracks/sheaf_track_validation.py
@@ -38,7 +38,22 @@ def validate_sheaf_track_artifacts(project_root: Path, *, validate_saved_certifi
     provenance = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["provenance"])
     if provenance.get("schema") != "template_active_inference.artifact_provenance.v1":
         issues.append("artifact_provenance.json schema mismatch")
-    if provenance.get("all_records_complete") is not True or provenance.get("all_bundles_complete") is not True:
+    provenance_rows = provenance.get("rows") or []
+    provenance_bundles = provenance.get("bundles") or []
+    # Recompute the aggregates exactly as build_artifact_provenance derives them so a
+    # row-only forgery (rows contradict a True stored flag) cannot pass.
+    provenance_records_complete = bool(provenance_rows) and all(
+        row.get("complete") or row.get("cycle_excluded") for row in provenance_rows
+    )
+    provenance_bundles_complete = bool(provenance_bundles) and all(
+        bundle.get("complete") for bundle in provenance_bundles
+    )
+    if (
+        provenance.get("all_records_complete") is not True
+        or provenance.get("all_records_complete") != provenance_records_complete
+        or provenance.get("all_bundles_complete") is not True
+        or provenance.get("all_bundles_complete") != provenance_bundles_complete
+    ):
         issues.append("artifact_provenance.json has incomplete provenance rows or bundles")
 
     replay = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["replay_matrix"])
@@ -134,30 +149,71 @@ def validate_sheaf_track_artifacts(project_root: Path, *, validate_saved_certifi
     dependency = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["dependency"])
     if dependency.get("schema") != _tracks.DEPENDENCY_SCHEMA:
         issues.append("validation_dependency_graph.json schema mismatch")
-    if dependency.get("all_required_edge_types_present") is not True:
+    # Recompute from the edge_types rows exactly as build_validation_dependency_graph
+    # derives the flag, so a row-only forgery (edge_types stripped while the flag stays
+    # True) cannot pass the trust-the-flag read.
+    dependency_edge_types = set(dependency.get("edge_types") or [])
+    dependency_required_present = set(_tracks.REQUIRED_EDGE_TYPES).issubset(dependency_edge_types)
+    if (
+        dependency.get("all_required_edge_types_present") is not True
+        or dependency.get("all_required_edge_types_present") != dependency_required_present
+    ):
         issues.append("validation_dependency_graph.json lacks required edge types")
+    # NOTE: the requested cross-linking check (flag any edge whose target is unresolvable
+    # to a known node) was evaluated and intentionally NOT added. The generated graph has
+    # 83 legitimate target-only nodes (sections, claim ids, bundle ids, copied-output
+    # paths, ...) that never appear as an edge source or artifact key, so there is no
+    # cheap node registry that distinguishes a forged dangling target from a real leaf
+    # node without breaking the positive (correctly-produced) artifact. Per the task this
+    # is the "if cheaply available" case — it is not, so the edge-types recompute above is
+    # the hardening here.
 
     section_status = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["section_status"])
     if section_status.get("schema") != "template_active_inference.sheaf_section_status_matrix.v1":
         issues.append("sheaf_section_status_matrix.json schema mismatch")
-    if section_status.get("all_bound_fragments_present") is not True:
+    # Recompute exactly as build_sheaf_section_status_matrix derives the flags so a
+    # row-only forgery (e.g. a section/track row with a blank status, or a stale
+    # missing_required_count) cannot pass a bare flag read.
+    section_status_bound_present = section_status.get("missing_required_count") == 0
+    section_summaries = section_status.get("sections") or []
+    track_summaries = section_status.get("tracks") or []
+    section_status_sections_have_status = bool(section_summaries) and all(
+        bool(row.get("status")) for row in section_summaries
+    )
+    section_status_tracks_have_status = bool(track_summaries) and all(
+        bool(row.get("status")) for row in track_summaries
+    )
+    if (
+        section_status.get("all_bound_fragments_present") is not True
+        or section_status.get("all_bound_fragments_present") != section_status_bound_present
+    ):
         issues.append("sheaf_section_status_matrix.json has missing bound fragments")
     if (
         section_status.get("all_sections_have_status") is not True
+        or section_status.get("all_sections_have_status") != section_status_sections_have_status
         or section_status.get("all_tracks_have_status") is not True
+        or section_status.get("all_tracks_have_status") != section_status_tracks_have_status
     ):
         issues.append("sheaf_section_status_matrix.json has incomplete status rows")
 
     render_log = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["render_log"])
     if render_log.get("schema") != "template_active_inference.sheaf_render_log.v1":
         issues.append("sheaf_render_log.json schema mismatch")
-    if render_log.get("all_events_ok") is not True:
+    # Recompute exactly as build_sheaf_render_log derives all_events_ok so a row-only
+    # forgery (a failed event row left while the flag stays True) cannot pass.
+    render_log_events = render_log.get("events") or []
+    render_log_events_ok = bool(render_log_events) and all(event.get("status") == "ok" for event in render_log_events)
+    if render_log.get("all_events_ok") is not True or render_log.get("all_events_ok") != render_log_events_ok:
         issues.append("sheaf_render_log.json has failed render events")
 
     scope = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["track_improvement_scope"])
     if scope.get("schema") != "template_active_inference.track_improvement_scope.v1":
         issues.append("track_improvement_scope.json schema mismatch")
-    if scope.get("all_live_tracks_valid") is not True:
+    # Recompute exactly as build_track_improvement_scope derives all_live_tracks_valid
+    # (from the promotion_matrix rows) so a row-only forgery cannot pass.
+    promotion_matrix = scope.get("promotion_matrix") or []
+    scope_live_tracks_valid = bool(promotion_matrix) and all(row.get("promotion_complete") for row in promotion_matrix)
+    if scope.get("all_live_tracks_valid") is not True or scope.get("all_live_tracks_valid") != scope_live_tracks_valid:
         issues.append("track_improvement_scope.json has incomplete live-track promotion rows")
 
     blocked = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["blocked_scope_manifest"])
@@ -185,7 +241,17 @@ def validate_sheaf_track_artifacts(project_root: Path, *, validate_saved_certifi
     release = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["release_bundle"])
     if release.get("schema") != "template_active_inference.release_bundle_manifest.v1":
         issues.append("release_bundle_manifest.json schema mismatch")
-    if release.get("all_required_sources_present") is not True:
+    # Recompute exactly as build_release_bundle_manifest derives the flag (each row is
+    # present iff source_exists OR deferred_until_render) so a row-only forgery cannot
+    # pass a bare flag read.
+    release_rows = release.get("rows") or []
+    release_sources_present = bool(release_rows) and all(
+        row.get("source_exists") or row.get("deferred_until_render") for row in release_rows
+    )
+    if (
+        release.get("all_required_sources_present") is not True
+        or release.get("all_required_sources_present") != release_sources_present
+    ):
         issues.append("release_bundle_manifest.json is missing required deliverables")
 
     theorem = _tracks._load_json(root / _tracks.CANONICAL_ARTIFACTS["theorem_traceability"])

--- a/projects/templates/template_active_inference/src/validation_spine/artifacts.py
+++ b/projects/templates/template_active_inference/src/validation_spine/artifacts.py
@@ -458,6 +458,13 @@ def validate_reproducibility_replay(project_root: Path, *, rebuild: bool = False
     saved_checks = saved.get("checks") or []
     if not saved_checks:
         issues.append("reproducibility_replay.json has no checks")
+    # Re-derive the aggregate from the per-row results rather than trusting the
+    # stored scalar. A forger can flip a row's passed=false while leaving the
+    # top-level all_passed=true; recomputing and requiring agreement catches that
+    # rows-vs-aggregate forgery without re-running any producer.
+    recomputed_all_passed = all(row.get("passed") is True for row in saved_checks)
+    if bool(saved.get("all_passed")) != recomputed_all_passed:
+        issues.append("reproducibility_replay.json all_passed disagrees with per-row results")
     for row in saved_checks:
         row_id = row.get("id", "<unknown>")
         if row.get("passed") is not True:

--- a/projects/templates/template_active_inference/src/visualizations/figures.py
+++ b/projects/templates/template_active_inference/src/visualizations/figures.py
@@ -183,71 +183,104 @@ def figure_free_energy_curve(project_root: Path) -> Path:
     return out
 
 
+def _gluing_rows_from_edges(graph: dict, *, top_n: int = 14) -> list[dict]:
+    """Derive the highest-fan-out artifact rows from the real dependency edges.
+
+    Reads ``graph["edges"]`` (not a hardcoded artifact list): the producer comes
+    from the ``produces`` edge, consumers from ``consumed_by`` edges, and gates
+    from ``validated_by`` edges. Artifacts are ranked by real fan-out degree
+    (consumers + gates) so the figure reflects — and changes with — the actual
+    topology. Ordering is fully deterministic: degree desc, then path asc.
+    """
+    edges = graph.get("edges") or []
+    producer_of: dict[str, str] = {}
+    consumers_of: dict[str, list[str]] = {}
+    gates_of: dict[str, list[str]] = {}
+    for edge in edges:
+        kind = edge.get("kind")
+        source = str(edge.get("source", ""))
+        target = str(edge.get("target", ""))
+        if kind == "produces":
+            producer_of[target] = source
+        elif kind == "consumed_by":
+            consumers_of.setdefault(source, []).append(target)
+        elif kind == "validated_by":
+            gates_of.setdefault(source, []).append(target)
+    artifacts = sorted(set(producer_of) | set(consumers_of) | set(gates_of))
+    rows: list[dict] = []
+    for rel in artifacts:
+        consumers = sorted(set(consumers_of.get(rel, [])))
+        gates = sorted(set(gates_of.get(rel, [])))
+        rows.append(
+            {
+                "artifact": rel,
+                "producer": producer_of.get(rel, "?"),
+                "consumers": consumers,
+                "gates": gates,
+                "fan_out": len(consumers) + len(gates),
+            }
+        )
+    rows.sort(key=lambda row: (-row["fan_out"], row["artifact"]))
+    return rows[:top_n]
+
+
 def figure_semantic_gluing_graph(project_root: Path) -> Path:
     root = project_root.resolve()
     style = load_figure_style(root)
     from manuscript.sheaf.semantic import build_validation_dependency_graph
 
     graph = build_validation_dependency_graph(root)
-    selected = [
-        "output/data/sheaf_gluing_certificate.json",
-        "output/data/sheaf_evidence_crosswalk.json",
-        "output/data/validation_dependency_graph.json",
-        "output/data/artifact_provenance.json",
-        "output/reports/replay_matrix.json",
-        "output/data/sensitivity_sweep.json",
-        "output/data/uncertainty_summary.json",
-        "output/data/toy_benchmark_matrix.json",
-        "output/data/interop_roundtrip_report.json",
-        "output/reports/model_checking_witnesses.json",
-        "output/reports/adversarial_audit.json",
-        "output/data/evidence_field_index.json",
-        "output/reports/release_bundle_manifest.json",
-        "output/data/theorem_traceability_matrix.json",
-    ]
     artifacts = graph.get("artifacts") or {}
+    rows = _gluing_rows_from_edges(graph)
     out = figure_output_path(root, "semantic_gluing_graph")
     with apply_style(style):
-        fig, ax = plt.subplots(figsize=(9.6, 5.6))
+        fig, ax = plt.subplots(figsize=(10.4, 6.0))
         ax.axis("off")
-        producer_x, artifact_x, consumer_x = 0.05, 0.42, 0.78
-        y_positions = np.linspace(0.86, 0.14, len(selected))
+        producer_x, artifact_x, consumer_x = 0.04, 0.40, 0.74
+        y_positions = np.linspace(0.86, 0.10, max(1, len(rows)))
         ax.text(producer_x, 0.96, "Producer script", weight="bold", color=style.color("primary"))
         ax.text(artifact_x, 0.96, "Evidence artifact", weight="bold", color=style.color("primary"))
-        ax.text(consumer_x, 0.96, "Consumer / gate", weight="bold", color=style.color("primary"))
-        for y, rel in zip(y_positions, selected, strict=True):
-            record = artifacts.get(rel, {})
-            producer = str(record.get("producer", "?"))
-            consumers = ", ".join(record.get("consumers") or record.get("validation_gates") or ["validate_outputs"])
-            ok = bool(record.get("produced_by_configured_analysis"))
+        ax.text(consumer_x, 0.96, "Consumers / gates (fan-out)", weight="bold", color=style.color("primary"))
+        for y, row in zip(y_positions, rows, strict=False):
+            rel = str(row["artifact"])
+            producer = str(row["producer"])
+            targets = list(row["consumers"]) + [f"[{gate}]" for gate in row["gates"]]
+            consumer_label = ", ".join(targets) if targets else "—"
+            if len(consumer_label) > 46:
+                consumer_label = consumer_label[:43] + "…"
+            ok = bool(artifacts.get(rel, {}).get("produced_by_configured_analysis"))
             box_color = style.color("pass") if ok else style.color("fail")
             ax.text(
                 producer_x,
                 y,
                 producer,
-                fontsize=8,
+                fontsize=7.5,
                 va="center",
-                bbox=dict(boxstyle="round,pad=0.25", facecolor="#f8fafc", edgecolor=box_color),
+                bbox=dict(boxstyle="round,pad=0.22", facecolor="#f8fafc", edgecolor=box_color),
             )
             ax.text(
                 artifact_x,
                 y,
                 rel.replace("output/", ""),
-                fontsize=8,
+                fontsize=7.5,
                 va="center",
-                bbox=dict(boxstyle="round,pad=0.25", facecolor="#ffffff", edgecolor=style.color("secondary")),
+                bbox=dict(boxstyle="round,pad=0.22", facecolor="#ffffff", edgecolor=style.color("secondary")),
             )
             ax.text(
                 consumer_x,
                 y,
-                consumers,
-                fontsize=8,
+                f"{consumer_label}  (×{row['fan_out']})",
+                fontsize=7.5,
                 va="center",
-                bbox=dict(boxstyle="round,pad=0.25", facecolor="#f8fafc", edgecolor=style.color("accent")),
+                bbox=dict(boxstyle="round,pad=0.22", facecolor="#f8fafc", edgecolor=style.color("accent")),
             )
-            ax.annotate("", xy=(artifact_x - 0.02, y), xytext=(producer_x + 0.24, y), arrowprops={"arrowstyle": "->"})
-            ax.annotate("", xy=(consumer_x - 0.02, y), xytext=(artifact_x + 0.29, y), arrowprops={"arrowstyle": "->"})
-        ax.set_title("Semantic sheaf gluing dependency graph", loc="left", pad=16)
+            ax.annotate("", xy=(artifact_x - 0.02, y), xytext=(producer_x + 0.23, y), arrowprops={"arrowstyle": "->"})
+            ax.annotate("", xy=(consumer_x - 0.02, y), xytext=(artifact_x + 0.27, y), arrowprops={"arrowstyle": "->"})
+        ax.set_title(
+            f"Semantic sheaf gluing dependency graph (top {len(rows)} by fan-out of {len(artifacts)} artifacts)",
+            loc="left",
+            pad=16,
+        )
         save_styled_figure(fig, out, style)
     return out
 

--- a/projects/templates/template_active_inference/src/visualizations/figures_diagrams.py
+++ b/projects/templates/template_active_inference/src/visualizations/figures_diagrams.py
@@ -137,16 +137,32 @@ def figure_multi_track_architecture(project_root: Path) -> Path:
     counts = structural_counts(root)
     pipeline_labels = _load_pipeline_track_labels(root)
     sheaf_labels = _load_sheaf_track_labels(root)
+    scientific = [
+        "Analytical oracle (Bernoulli–Ising)",
+        "pymdp T-maze harness",
+        "Sheaf composition contract",
+    ]
+    # Scale the canvas to the tallest column so no row runs off the axes or
+    # collides with the footer, no matter how many gates/fragments exist.
+    row_height = 0.42
+    max_rows = max(len(scientific), len(pipeline_labels), len(sheaf_labels))
+    top_y = 0.6  # space reserved above for column titles
+    footer_y = 0.45  # space reserved below for the summary footer
+    body_height = max_rows * row_height
+    ymax = top_y + body_height + footer_y
+    fig_h = max(5.5, ymax * 0.9)
     with styled_figure(root, "multi_track_architecture") as (style, out):
-        fig, ax = plt.subplots(figsize=(10, 5.5))
+        fig, ax = plt.subplots(figsize=(10, fig_h))
         ax.set_xlim(0, 10)
-        ax.set_ylim(0, 6)
+        ax.set_ylim(0, ymax)
         ax.axis("off")
+        title_y = ymax - top_y / 2
+        first_row_y = ymax - top_y
 
         def draw_column(x: float, title: str, items: list[str], width: float = 2.2) -> None:
-            ax.text(x + width / 2, 5.5, title, ha="center", va="bottom", fontsize=10, fontweight="bold")
+            ax.text(x + width / 2, title_y, title, ha="center", va="bottom", fontsize=10, fontweight="bold")
             for idx, label in enumerate(items):
-                y = 4.8 - idx * 0.42
+                y = first_row_y - idx * row_height
                 patch = FancyBboxPatch(
                     (x, y - 0.16),
                     width,
@@ -159,11 +175,6 @@ def figure_multi_track_architecture(project_root: Path) -> Path:
                 ax.add_patch(patch)
                 ax.text(x + 0.08, y, label, va="center", fontsize=7)
 
-        scientific = [
-            "Analytical oracle (Bernoulli–Ising)",
-            "pymdp T-maze harness",
-            "Sheaf composition contract",
-        ]
         draw_column(0.4, "Scientific tracks (3)", scientific, width=2.6)
         draw_column(3.5, f"Pipeline gates ({len(pipeline_labels)})", pipeline_labels, width=2.5)
         draw_column(
@@ -172,7 +183,10 @@ def figure_multi_track_architecture(project_root: Path) -> Path:
             sheaf_labels,
             width=2.8,
         )
-        for y in (2.5, 3.0, 3.5):
+        # Inter-column flow arrows centred in the body band.
+        band_center = first_row_y - body_height / 2
+        for offset in (-row_height, 0.0, row_height):
+            y = band_center + offset
             ax.annotate(
                 "",
                 xy=(3.4, y),
@@ -187,7 +201,7 @@ def figure_multi_track_architecture(project_root: Path) -> Path:
             )
         ax.text(
             5.0,
-            0.35,
+            footer_y / 2,
             (
                 f"{counts['imrad_manifest_rows']} manifest rows · "
                 f"{counts['coverage_present']} present / {counts['coverage_bound']} bound"

--- a/projects/templates/template_active_inference/tests/gates/test_output_gates.py
+++ b/projects/templates/template_active_inference/tests/gates/test_output_gates.py
@@ -139,3 +139,83 @@ def test_validate_outputs_negative_missing_sweep(project_root: Path, tmp_path: P
     finally:
         if backup.is_file():
             sweep.write_bytes(backup.read_bytes())
+
+
+@pytest.mark.timeout(300)
+def test_figures_nonblank_passes_on_real_tree(project_root: Path) -> None:
+    """Positive control: bootstrapped figures satisfy the integrity gate."""
+    ensure_gate_artifacts(project_root)
+    checks = validate_outputs(project_root)
+    assert checks.get("figures_nonblank") is True
+
+
+@pytest.mark.timeout(300)
+def test_figures_nonblank_negative_blank_png(project_root: Path, tmp_path: Path) -> None:
+    """A 0-byte PNG (empty-file sha is truthy under exists()) must fail the gate."""
+    ensure_gate_artifacts(project_root)
+    target = project_root / "output" / "figures" / "ising_mi_curve.png"
+    assert target.is_file(), "expected bootstrapped figure to exist"
+    backup = tmp_path / "ising_mi_curve.png.bak"
+    backup.write_bytes(target.read_bytes())
+    try:
+        target.write_bytes(b"")  # 0-byte blank figure
+        checks = validate_outputs(project_root)
+        assert checks.get("figures_nonblank") is False
+        assert checks.get("experiment_plan_metrics") is False
+        # The mere-existence check still passes, proving the new check is what catches it.
+        assert checks.get("output/figures/ising_mi_curve.png") is True
+    finally:
+        target.write_bytes(backup.read_bytes())
+
+
+@pytest.mark.timeout(300)
+def test_reproducibility_replay_rebuild_passes_on_real_tree(project_root: Path) -> None:
+    """Positive control: the real rebuild=True replay reproduces every producer."""
+    from validation_spine import validate_reproducibility_replay
+
+    ensure_gate_artifacts(project_root)
+    assert validate_reproducibility_replay(project_root, rebuild=True) == []
+
+
+@pytest.mark.timeout(300)
+def test_reproducibility_replay_rebuild_catches_forged_sweep(project_root: Path, tmp_path: Path) -> None:
+    """A forged parameter_sweep.csv must make rebuild=True replay report a mismatch."""
+    from validation_spine import validate_reproducibility_replay
+
+    ensure_gate_artifacts(project_root)
+    sweep = project_root / "output" / "data" / "parameter_sweep.csv"
+    assert sweep.is_file(), "expected bootstrapped parameter sweep"
+    backup = tmp_path / "parameter_sweep.csv.bak"
+    backup.write_bytes(sweep.read_bytes())
+    try:
+        sweep.write_text(sweep.read_text(encoding="utf-8") + "forged,row,values\n", encoding="utf-8")
+        issues = validate_reproducibility_replay(project_root, rebuild=True)
+        assert any("parameter_sweep_replay" in issue for issue in issues), issues
+    finally:
+        sweep.write_bytes(backup.read_bytes())
+
+
+def test_reproducibility_replay_recompute_catches_rows_vs_aggregate_forgery(
+    project_root: Path, tmp_path: Path
+) -> None:
+    """Flipping a row to passed=false while leaving all_passed=true must be caught (cheap path)."""
+    from validation_spine import validate_reproducibility_replay
+
+    path = project_root / "output" / "reports" / "reproducibility_replay.json"
+    if not path.is_file():
+        ensure_gate_artifacts(project_root)
+    assert path.is_file()
+    backup = tmp_path / "reproducibility_replay.json.bak"
+    backup.write_bytes(path.read_bytes())
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        rows = payload.get("checks") or []
+        assert rows, "expected replay checks to forge"
+        rows[0]["passed"] = False  # forge a failing row, keep aggregate all_passed=true
+        payload["checks"] = rows
+        payload["all_passed"] = True
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        issues = validate_reproducibility_replay(project_root, rebuild=False)
+        assert any("all_passed disagrees with per-row results" in issue for issue in issues), issues
+    finally:
+        path.write_bytes(backup.read_bytes())

--- a/projects/templates/template_active_inference/tests/test_roadmap_promotion.py
+++ b/projects/templates/template_active_inference/tests/test_roadmap_promotion.py
@@ -496,6 +496,20 @@ def test_promoted_claims_have_falsifiable_negative_controls(project_root: Path) 
         data["rows"][0]["passed"] = False  # a real invariant violation
         data["all_passed"] = True
 
+    def break_diffoscope(data: dict) -> None:
+        # A row reports the live artifact differs from its provenance hash, yet the
+        # summary bit is left true. The validator must re-derive all_equal from rows.
+        data["rows"][0]["equal"] = False
+        data["all_equal"] = True
+
+    def break_figure_source_map(data: dict) -> None:
+        # Inject a fabricated, non-existent SOURCE-CODE path (src/**, not output/**)
+        # while claiming the row is mapped. The validator must re-check the path on
+        # the filesystem rather than trust the stored mapped/all_figures_mapped bits.
+        data["rows"][0]["sources"] = ["src/__fabricated_does_not_exist__.py"]
+        data["rows"][0]["mapped"] = True
+        data["all_figures_mapped"] = True
+
     cases = [
         (
             project_root / "output" / "reports" / "producer_completeness.json",
@@ -514,6 +528,18 @@ def test_promoted_claims_have_falsifiable_negative_controls(project_root: Path) 
             break_invariant,
             validate_toy_sweep_artifacts,
             "graph_world_invariants.json records a failing invariant",
+        ),
+        (
+            project_root / "output" / "reports" / "artifact_diffoscope.json",
+            break_diffoscope,
+            validate_integration_audit_artifacts,
+            "artifact_diffoscope.json records artifact drift",
+        ),
+        (
+            project_root / "output" / "data" / "figure_source_map.json",
+            break_figure_source_map,
+            validate_integration_audit_artifacts,
+            "figure_source_map.json has unmapped figures",
         ),
     ]
     for path, mutate, validator, expected_issue in cases:

--- a/projects/templates/template_active_inference/tests/test_track_consolidation.py
+++ b/projects/templates/template_active_inference/tests/test_track_consolidation.py
@@ -380,6 +380,111 @@ def test_canonical_sheaf_negative_controls(project_root: Path) -> None:
         write_sheaf_track_artifacts(project_root)
 
 
+def test_canonical_sheaf_row_only_forgeries_are_caught(project_root: Path) -> None:
+    """Row-only forgeries (rows contradict a True stored aggregate) must be caught.
+
+    Each mutation here corrupts ONLY a row (or an edge / edge-type list) and leaves the
+    stored aggregate boolean True. A trust-the-flag check (read the flag, never recompute
+    from the rows) passes every one of these; the hardened checks recompute the aggregate
+    from its rows exactly as the generator derives it and require stored == recomputed.
+    """
+    from roadmap_tracks import validate_sheaf_track_artifacts, write_sheaf_track_artifacts
+
+    ensure_gate_artifacts(project_root)
+    write_sheaf_track_artifacts(project_root)
+    paths = {
+        "provenance": project_root / "output" / "data" / "artifact_provenance.json",
+        "dependency": project_root / "output" / "data" / "validation_dependency_graph.json",
+        "section_status": project_root / "output" / "data" / "sheaf_section_status_matrix.json",
+        "render_log": project_root / "output" / "reports" / "sheaf_render_log.json",
+        "scope": project_root / "output" / "data" / "track_improvement_scope.json",
+        "release": project_root / "output" / "reports" / "release_bundle_manifest.json",
+    }
+    originals = {path: path.read_text(encoding="utf-8") for path in paths.values()}
+    try:
+        # provenance: a row contradicts the True all_records_complete aggregate.
+        data = _load(paths["provenance"])
+        data["rows"][0]["complete"] = False
+        data["rows"][0]["cycle_excluded"] = False
+        assert data["all_records_complete"] is True
+        _write(paths["provenance"], data)
+        assert any(
+            "incomplete provenance rows or bundles" in issue for issue in validate_sheaf_track_artifacts(project_root)
+        )
+        paths["provenance"].write_text(originals[paths["provenance"]], encoding="utf-8")
+
+        # provenance: a bundle contradicts the True all_bundles_complete aggregate.
+        data = _load(paths["provenance"])
+        data["bundles"][0]["complete"] = False
+        assert data["all_bundles_complete"] is True
+        _write(paths["provenance"], data)
+        assert any(
+            "incomplete provenance rows or bundles" in issue for issue in validate_sheaf_track_artifacts(project_root)
+        )
+        paths["provenance"].write_text(originals[paths["provenance"]], encoding="utf-8")
+
+        # dependency: drop a required edge type while leaving the flag True.
+        data = _load(paths["dependency"])
+        data["edge_types"] = [kind for kind in data["edge_types"] if kind != "producer_to_track"]
+        assert data["all_required_edge_types_present"] is True
+        _write(paths["dependency"], data)
+        assert any("lacks required edge types" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["dependency"].write_text(originals[paths["dependency"]], encoding="utf-8")
+
+        # section_status: stale missing_required_count vs True all_bound_fragments_present.
+        data = _load(paths["section_status"])
+        data["missing_required_count"] = 1
+        assert data["all_bound_fragments_present"] is True
+        _write(paths["section_status"], data)
+        assert any("missing bound fragments" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["section_status"].write_text(originals[paths["section_status"]], encoding="utf-8")
+
+        # section_status: a section row with a blank status vs True all_sections_have_status.
+        data = _load(paths["section_status"])
+        data["sections"][0]["status"] = ""
+        assert data["all_sections_have_status"] is True
+        _write(paths["section_status"], data)
+        assert any("incomplete status rows" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["section_status"].write_text(originals[paths["section_status"]], encoding="utf-8")
+
+        # section_status: a track row with a blank status vs True all_tracks_have_status.
+        data = _load(paths["section_status"])
+        data["tracks"][0]["status"] = ""
+        assert data["all_tracks_have_status"] is True
+        _write(paths["section_status"], data)
+        assert any("incomplete status rows" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["section_status"].write_text(originals[paths["section_status"]], encoding="utf-8")
+
+        # render_log: a failed event row vs True all_events_ok.
+        data = _load(paths["render_log"])
+        data["events"][0]["status"] = "failed"
+        assert data["all_events_ok"] is True
+        _write(paths["render_log"], data)
+        assert any("failed render events" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["render_log"].write_text(originals[paths["render_log"]], encoding="utf-8")
+
+        # scope: an incomplete promotion row vs True all_live_tracks_valid.
+        data = _load(paths["scope"])
+        data["promotion_matrix"][0]["promotion_complete"] = False
+        assert data["all_live_tracks_valid"] is True
+        _write(paths["scope"], data)
+        assert any("live-track promotion rows" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["scope"].write_text(originals[paths["scope"]], encoding="utf-8")
+
+        # release_bundle: a missing source row vs True all_required_sources_present.
+        data = _load(paths["release"])
+        data["rows"][0]["source_exists"] = False
+        data["rows"][0]["deferred_until_render"] = False
+        assert data["all_required_sources_present"] is True
+        _write(paths["release"], data)
+        assert any("missing required deliverables" in issue for issue in validate_sheaf_track_artifacts(project_root))
+        paths["release"].write_text(originals[paths["release"]], encoding="utf-8")
+    finally:
+        for path, text in originals.items():
+            path.write_text(text, encoding="utf-8")
+        write_sheaf_track_artifacts(project_root)
+
+
 def test_canonical_track_contract_negative_controls(project_root: Path) -> None:
     from roadmap_tracks import validate_sheaf_track_artifacts, write_sheaf_track_artifacts
 


### PR DESCRIPTION
A RedTeam (VectorSpecialists, verifier-first) of the multi-track sheaf **meta-infrastructure** (not the AIF science) found a systematic **trust-the-flag** weakness: integrity validators read a stored aggregate boolean without recomputing from rows, and negative-control tests flipped flag+row together — so **row-only forgeries passed**. This hardens the gates to recompute from ground truth + cross-check, each with a negative control that flips *only* the aggregate.

**Critical fixes**
- `reproducibility_replay` never replayed (`rebuild=False`, self-referential hash) → re-derive `all_passed` from rows + a `rebuild=True` real-replay test that catches a non-reproducible artifact.
- `artifact_provenance` pure trust-the-flag → recompute from rows/bundles + cross-check.
- Figure gates accepted blank/0-byte PNGs (0-byte sha is truthy) → new `figures_nonblank` gate (≥5KB + PIL dims>0), folded into `experiment_plan_metrics` + `REQUIRED_OUTPUT_CHECK_KEYS`.

**Hardened (recompute-from-rows + cross-check):** `diffoscope`, `dependency` (edge types), `section_status`, `render_log`, `scope`, `release_bundle`, `release_notes`; `figure_source_map.mapped` now requires source-code paths to exist (output/ deferred).

**Visualizations:** `semantic_gluing_graph` now renders the real 78-edge dependency topology (hash-sensitive to edges) instead of a fixed mislabeled table; `multi_track_architecture` y-range scaled so all 33 rows fit (was overflowing).

Every hardened check has a **negative-control test** (row-only forgery / 0-byte PNG / fabricated source path / non-reproducible artifact) — the missing test class. **Full active_inference suite 348/349, coverage 90.9% (up); PDF renders (2.45 MB); ruff/mypy clean.**

**Reported, not auto-fixed (behavior-changing / arguable):** `validated`-status track-claim laundering (40/76 cells), empty-fragment→`present`, dependency edge-*target* resolution (83 legitimate leaf nodes).