### PR TITLE
docs: deep-review accuracy fixes (counts, anchors, roadmap, version policy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,9 @@ headers. Full surface and worked usage examples:
 
 Prerequisites: `pandoc` and a TeX distribution (`texlive-xetex` on Debian/Ubuntu,
 MacTeX on macOS). Python deps install with `uv sync` (project interpreter is
-`.venv/bin/python`, Python 3.12 per
-[`.python-version`](.python-version)). Add per-project deps with
+`.venv/bin/python`; the template targets Python 3.10+ (`requires-python` in
+[`pyproject.toml`](pyproject.toml)) and CI tests 3.10–3.12, with
+[`.python-version`](.python-version) pinning 3.12 as the local default). Add per-project deps with
 `uv run python scripts/manage_workspace.py add <package> --project <name>`. To
 generate a manuscript, follow the [Quickstart](#quickstart) at the top.
 

--- a/docs/_generated/canonical_facts.md
+++ b/docs/_generated/canonical_facts.md
@@ -105,11 +105,11 @@ uv run pytest tests/infra_tests/publishing/ --collect-only -q --no-cov
 
 Result: **214** project-scope infrastructure tests collected and **381** publishing tests collected. Full behavioral gates still live in CI and in the verification commands listed by the relevant `AGENTS.md` files.
 
-**Exemplar `pytest --collect-only` totals** (2026-05-27):
+**Exemplar `pytest --collect-only` totals** (2026-05-27; `template_active_inference` re-derived 2026-06-05 after the v3.2.0 validation-spine additions):
 
 | Project | Tests collected | `src/` line+branch coverage |
 |---------|-----------------|----------------------------|
-| `template_active_inference` | 269 | 91.35 % |
+| `template_active_inference` | 343 | 91.35 % |
 | `template_autoresearch_project` | 220 | 92.81 % |
 | `template_autoscientists` | 79 | 99.59 % |
 | `template_code_project` | 196 | 98.25 % |

--- a/docs/best-practices/migration-guide.md
+++ b/docs/best-practices/migration-guide.md
@@ -583,7 +583,7 @@ cp quadmath/scripts/* scripts/
 # Update dependencies
 ```
 
-**See:** [README.md Migration Section](../README.md#migration-from-quadmath)
+**See:** [README.md Migration Section](../../README.md#migration-from-quadmath)
 
 ### From Other Research Templates
 

--- a/docs/core/how-to-use.md
+++ b/docs/core/how-to-use.md
@@ -283,7 +283,7 @@ Level 10-12: Expert Usage (1-2 months)
 ### Advanced Topics
 
 - **[Two-Layer Architecture](../architecture/two-layer-architecture.md)** - architecture guide
-- **[Modules Guide](../modules/modules-guide.md)** - Using all 14 infrastructure modules
+- **[Modules Guide](../modules/modules-guide.md)** - Using the infrastructure modules (current count in [`_generated/canonical_facts.md`](../_generated/canonical_facts.md))
 - **[Dependency management](../../README.md)** - `uv` usage and install/sync commands
 - **[CI/CD automation](../../.github/README.md)** - GitHub Actions and repository automation
 - **[Performance Optimization](../operational/config/performance-optimization.md)** - Build time optimization

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -5,12 +5,23 @@ infrastructure. Architecture details:
 [`architecture.md`](../core/architecture.md) and
 [`workflow.md`](../core/workflow.md).
 
-**Last verified:** 2026-05-31 (post-`v3.1.0` backlog refresh; measured
+**Last verified:** 2026-06-05 (post-`v3.2.0` release; measured
 metrics defer to [`TO-DO.md`](../../TO-DO.md) and
 [`docs/_generated/canonical_facts.md`](../_generated/canonical_facts.md)
 unless this file is re-measured)
 
 ## Completed Releases
+
+### v3.2.0 — Format, Logging, and Exemplar Hardening (2026-06-04)
+
+- added optional Pandoc-backed DOCX/EPUB rendering with per-format toggles
+  (default off)
+- extended the Active Inference validation spine with producer completeness,
+  stale-artifact checks, and dependency graph v2
+- hardened the public SIA harness boundary and re-baselined coverage gaps
+- closed GitHub supply-chain hygiene (SHA-pinned actions, `actionlint` gate,
+  guarded Dependabot automerge) and the XML-parser policy
+- see [`CHANGELOG.md`](../../CHANGELOG.md) for the full entry
 
 ### v3.1.0 — Public Exemplar / Validation-Spine Release (2026-05-30)
 
@@ -90,13 +101,12 @@ and **Major**.
 - land the Active Inference gate-cache follow-up without changing the immutable
   `v3.1.0` tag
 
-### v3.2.0 — Format, Logging, and Exemplar Hardening
+### Next (open backlog)
 
-- finish terminal logging cleanup and preserve verbose file logs
-- add optional DOCX/EPUB rendering with per-format toggles
-- extend the Active Inference validation spine with producer completeness,
-  stale-artifact checks, and dependency graph v2
-- harden the public SIA harness boundary and re-baseline coverage gaps
+- finish terminal logging cleanup and preserve verbose file logs (LOG-CLEAN-1)
+- land the Active Inference gate-cache follow-up (AI-GATE-CACHE-1)
+- consolidate the defensive markdown-read helper and derive the CI project
+  matrix from the generated roster (READFILE-SAFE-1, CI-MATRIX-DYNAMIC-1)
 
 ### Next Generation (vision)
 

--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -6,8 +6,8 @@ We actively maintain security for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.1.x   | ✅ Yes             |
-| < 3.1   | ❌ No              |
+| 3.2.x   | ✅ Yes             |
+| < 3.2   | ❌ No              |
 
 ## 🐛 **Reporting a Vulnerability**
 

--- a/docs/documentation-index.md
+++ b/docs/documentation-index.md
@@ -41,7 +41,7 @@ This index lists documentation files in the Research Project Template by categor
 ---
 
 > [!IMPORTANT]
-> **Multi-project pipeline pitfalls** (root venv deps, `matplotlib` in core deps, `project_config:` namespace, idempotency) — authoritative copy in [docs/AGENTS.md](AGENTS.md#learnings--known-issues) and [guides/new-project-setup.md](guides/new-project-setup.md#pitfall-6-project-specific-packages-absent-from-root-venv--silent-stage-4-failure).
+> **Multi-project pipeline pitfalls** (root venv deps, `matplotlib` in core deps, `project_config:` namespace, idempotency) — authoritative copy in [docs/AGENTS.md](AGENTS.md#learnings--known-issues) and [guides/new-project-setup.md](guides/new-project-setup.md#pitfall-6-root-venv).
 
 ## Topic routing (canonical → deep dives)
 
@@ -71,6 +71,7 @@ Development standards are documented in **`docs/rules/`**. The Cursor IDE entry 
 - **[`rules/infrastructure_modules.md`](rules/infrastructure_modules.md)** - Infrastructure module development
 - **[`rules/testing_standards.md`](rules/testing_standards.md)** - Testing patterns
 - **[`rules/documentation_standards.md`](rules/documentation_standards.md)** - Documentation writing guide
+- **[`rules/memory_and_decision_records.md`](rules/memory_and_decision_records.md)** - Decision-memory and rationale tiering
 - **[`rules/type_hints_standards.md`](rules/type_hints_standards.md)** - Type annotation patterns
 - **[`rules/llm_standards.md`](rules/llm_standards.md)** - LLM/Ollama integration
 - **[`rules/code_style.md`](rules/code_style.md)** - Code formatting
@@ -124,6 +125,7 @@ Development standards are documented in **`docs/rules/`**. The Cursor IDE entry 
 - **[architecture/adrs/002-declarative-dag-pipeline.md](architecture/adrs/002-declarative-dag-pipeline.md)** - ADR-002: Declarative DAG pipeline
 - **[architecture/adrs/003-multi-format-rendering-and-toggles.md](architecture/adrs/003-multi-format-rendering-and-toggles.md)** - ADR-003: Multi-format rendering and toggles
 - **[architecture/adrs/004-zero-mock-testing-policy.md](architecture/adrs/004-zero-mock-testing-policy.md)** - ADR-004: Zero-mock testing policy
+- **[architecture/adrs/005-decision-memory-and-adversarial-validation.md](architecture/adrs/005-decision-memory-and-adversarial-validation.md)** - ADR-005: Decision memory and adversarial validation
 - **[core/workflow.md](core/workflow.md)** - Development workflow
 - **[architecture/testing-strategy.md](architecture/testing-strategy.md)** - Testing strategy overview
 - **[architecture/discovery-export-synthesis.md](architecture/discovery-export-synthesis.md)** - Discovery and export patterns
@@ -330,6 +332,12 @@ Development standards are documented in **`docs/rules/`**. The Cursor IDE entry 
 - **[prompts/comprehensive-assessment/SKILL.md](prompts/comprehensive-assessment/SKILL.md)** - Assessment and review
 - **[prompts/reproducibility-audit/SKILL.md](prompts/reproducibility-audit/SKILL.md)** - Determinism and regenerate-from-clean audit
 - **[prompts/pipeline-debugging/SKILL.md](prompts/pipeline-debugging/SKILL.md)** - Pipeline DAG-stage failure triage
+- **[prompts/academic-paper/SKILL.md](prompts/academic-paper/SKILL.md)** - Academic paper authoring
+- **[prompts/academic-paper-reviewer/SKILL.md](prompts/academic-paper-reviewer/SKILL.md)** - Academic paper review
+- **[prompts/academic-pipeline/SKILL.md](prompts/academic-pipeline/SKILL.md)** - Full academic pipeline
+- **[prompts/agentic-use/SKILL.md](prompts/agentic-use/SKILL.md)** - Agentic-use planning
+- **[prompts/deep-research/SKILL.md](prompts/deep-research/SKILL.md)** - Deep research synthesis
+- **[prompts/methods-orchestration/SKILL.md](prompts/methods-orchestration/SKILL.md)** - Methods orchestration
 
 ---
 

--- a/docs/reference/quick-start-cheatsheet.md
+++ b/docs/reference/quick-start-cheatsheet.md
@@ -172,7 +172,7 @@ Reference it: \ref{fig:my_figure}
 | **Figures missing** | Run `uv run python scripts/02_run_analysis.py --project template_code_project` first |
 | **References show ??** | Check label spelling and existence |
 | **Project not discovered** | Ensure the directory is under `projects/`, has `src/` with Python files, and has `tests/`; add `manuscript/config.yaml` before rendering |
-| **Stage 4 fails silently** | Check root pyproject.toml has project deps ([details](../guides/new-project-setup.md#pitfall-6-project-specific-packages-absent-from-root-venv--silent-stage-4-failure)) |
+| **Stage 4 fails silently** | Check root pyproject.toml has project deps ([details](../guides/new-project-setup.md#pitfall-6-root-venv)) |
 | **Config warnings** | Nest custom keys under `project_config:` |
 
 ## 📊 Key Metrics


### PR DESCRIPTION
## Summary

A deep multi-lens **RedTeam + IterativeDepth** review of `docs/` (366 files, 6 parallel verifier lenses, verify-don't-trust against the actual repo). Every fix below was confirmed against the tree.

## Fixes
- **core/how-to-use.md** — dropped the stale hardcoded "14 infrastructure modules" (canonical is 20); links to `canonical_facts.md` instead of a competing literal.
- **development/roadmap.md** — promoted **v3.2.0 Planned → Completed** (shipped 2026-06-04); refreshed "Last verified" to 2026-06-05; reframed the open-backlog block to current TO-DO IDs.
- **development/security.md** — supported-versions table **3.1.x → 3.2.x** (current release).
- **_generated/canonical_facts.md** — `template_active_inference` test count **269 → 343** (re-derived after the v3.2.0 spine additions; the only count I could verify reliably in its own venv).
- **documentation-index.md** — added missing entries: **ADR-005**, **rules/memory_and_decision_records.md**, and **6 prompt SKILLs** (academic-paper, academic-paper-reviewer, academic-pipeline, agentic-use, deep-research, methods-orchestration).
- **documentation-index.md + reference/quick-start-cheatsheet.md** — Pitfall-6 links → stable explicit anchor `#pitfall-6-root-venv` (heading-text-independent; both pointed at the long auto-slug before).
- **best-practices/migration-guide.md** — fixed README link path `../README.md` → `../../README.md` (the `migration-from-quadmath` anchor lives in the repo-root README, not docs/README.md).
- **README.md** — Python version stated as **3.10+** (`requires-python`; CI tests 3.10–3.12) instead of implying 3.12 is required.

## RedTeam note (verifier caught a false finding)
A lens flagged `#learnings--known-issues` (double hyphen) as broken. **Rejected** — that *is* the correct GitHub slug for the heading "Learnings & Known Issues" (`&` strips, leaving two spaces → `--`). Changing it would have broken a working link. Left as-is.

## Verification
- `lint_docs` links / consistency / doc-pairs — all exit 0 (run against this branch).
- Anchor targets confirmed to exist; new index entries confirmed on disk.
- Authored in an isolated worktree to avoid the active doc-rewriting co-actor in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)