### PR TITLE
docs(infra): thermo-nuclear close-out follow-ups

### DIFF
--- a/docs/operational/logging/output-design.md
+++ b/docs/operational/logging/output-design.md
@@ -70,7 +70,9 @@ NEXT STEPS
 
 This block is the canonical end-of-run summary. It is rendered by
 `format_multi_project_detailed_report` in
-[`infrastructure/core/pipeline/multi_project.py`](../../../infrastructure/core/pipeline/multi_project.py),
+[`infrastructure/reporting/multi_project_report.py`](../../../infrastructure/reporting/multi_project_report.py)
+(re-exported from
+[`infrastructure/core/pipeline/multi_project.py`](../../../infrastructure/core/pipeline/multi_project.py)),
 emitted by the orchestrator in
 [`infrastructure/orchestration/pipeline_runner.py`](../../../infrastructure/orchestration/pipeline_runner.py),
 and persisted verbatim to `docs/_generated/last-run-summary.md` after every

--- a/docs/operational/reporting-guide.md
+++ b/docs/operational/reporting-guide.md
@@ -298,8 +298,9 @@ fi
 ## Pipeline Summary Format
 
 The end-of-run terminal summary block is rendered by **`format_multi_project_detailed_report`**
-in [`infrastructure/core/pipeline/multi_project.py`](../../infrastructure/core/pipeline/multi_project.py).
-This is the **canonical pipeline-completion reporting surface** — every full-run option
+in [`infrastructure/reporting/multi_project_report.py`](../../infrastructure/reporting/multi_project_report.py)
+(re-exported from [`infrastructure/core/pipeline/multi_project.py`](../../infrastructure/core/pipeline/multi_project.py)
+for backward compatibility). This is the **canonical pipeline-completion reporting surface** — every full-run option
 (interactive menu, `./run.sh --pipeline`, and direct `infrastructure.orchestration` invocations)
 prints this block via the orchestrator in
 [`infrastructure/orchestration/pipeline_runner.py`](../../infrastructure/orchestration/pipeline_runner.py).

--- a/projects/templates/template_autoscientists/src/__init__.py
+++ b/projects/templates/template_autoscientists/src/__init__.py
@@ -23,6 +23,7 @@ from .search import SearchConfig, SearchResult, run_search
 from .stagnation import StagnationDetector, reorganize_axes
 from .state import Champion, ExperimentOutcome, Proposal, SharedState
 
+
 def __getattr__(name: str):  # pragma: no cover - lazy script-layer export
     if name == "HermesProposer":
         from hermes_proposer import HermesProposer

--- a/projects/templates/template_autoscientists/src/agents.py
+++ b/projects/templates/template_autoscientists/src/agents.py
@@ -15,7 +15,6 @@ needed to turn the deterministic reference run into a live agentic one.
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from typing import Protocol
 


### PR DESCRIPTION
## Summary

The thermo-nuclear close-out (waves F–O) landed on `main` in `8db3bb9a`. This PR adds the remaining polish:

- Point operational reporting docs at `infrastructure/reporting/multi_project_report.py` (canonical implementation) with a backward-compat re-export note for `core.pipeline.multi_project`.
- Apply autoscientists exemplar ruff cleanup (unused import + formatting) that was in the amended local commit but not the initial push.

## Context

- Audit report: `docs/audit/archived/thermo-nuclear-code-quality-2026-06-11-v2.md` — **Approve**, unified health 11/11 on close-out commit.
- Parent close-out: drift/integrity/link splits, test megamonolith splits, mermaid stadium→rect sweep, `QualityReportLike` protocol fix.

## Test plan

- [x] `uv run python -m infrastructure.core.health` (11/11 on close-out base)
- [x] Docs-only + trivial ruff changes; no runtime logic changes in this PR

Made with [Cursor](https://cursor.com)