### PR TITLE
ci(rehearsal): always summarize and upload the receipt, even on failure

### DIFF
--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -63,6 +63,7 @@ jobs:
           --execute --receipt clean_checkout_rehearsal_receipt.json
 
       - name: Summarize receipt
+        if: always()
         run: |
           {
             echo "## Clean-checkout rehearsal receipt"
@@ -72,6 +73,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload rehearsal receipt
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: clean-checkout-rehearsal-receipt


### PR DESCRIPTION
A red rehearsal skipped both the `Summarize receipt` and `Upload rehearsal receipt` steps, so the first hosted quick-profile dispatch (run 34088286458 — which surfaced the all-projects exit-aggregation bug, now isolated in `REHEARSAL-ANALYSIS-EXIT-1`) left **no receipt artifact**: the job log was the only evidence source.

The receipt — per-command records, digests, and the new redacted failure output tails — is exactly what makes a failed dispatch diagnosable. Both steps now run with `if: always()`, so every dispatch ships its receipt regardless of outcome.

Docs/workflow-only change (2 lines).