### PR TITLE
Fix equation references and desktop figure visibility in publication renders

### DIFF
--- a/infrastructure/rendering/README.md
+++ b/infrastructure/rendering/README.md
@@ -15,6 +15,9 @@ HTML rewrites retain the page's permissions and skip unchanged content. Shared
 confined writes protect HTML and rewritten Beamer TeX from temporary-file
 symlink redirection. Unsafe empty-path URI schemes are rejected like other
 unsupported links.
+Desktop figure links may extend beyond the prose column while remaining inside
+the viewport. The body must not clip these widened figures; narrow readers retain
+local table scrolling and responsive image sizing.
 
 ## Features
 

--- a/infrastructure/rendering/README.md
+++ b/infrastructure/rendering/README.md
@@ -583,6 +583,14 @@ the Stage 04/05 enabled-output gates require the complete pair in accessible
 mode. The default archive profile retains its historical required-Beamer and
 optional-Reveal behavior.
 
+The post-combined accessible refresh uses the current manuscript AUX for both
+local and cross-deck references. Labeled single-number `equation` environments
+also receive that canonical number as an explicit amsmath tag, preventing a
+standalone deck from printing `(1)` next to prose that refers to `(7)`. Missing
+canonical equation labels or conflicting authored tags fail the refresh.
+Unnumbered mathematics, standalone authoring, and archive numbering retain
+their existing behavior.
+
 Reveal postprocessing replaces every input viewport declaration with one
 zoom-permitting viewport, contains document-level horizontal overflow, and
 reserves nonoverlapping fixed lanes for the skip link, companion navigation,

--- a/infrastructure/rendering/SKILL.md
+++ b/infrastructure/rendering/SKILL.md
@@ -77,6 +77,12 @@ consume one composed Pandoc AST; any pair-member failure removes both outputs.
 Use `render_accessible_slide_pair()` for the same explicit programmatic
 contract. Archive mode keeps the historical Beamer-required behavior.
 
+During the canonical post-combined refresh, accessible Beamer decks resolve
+local and cross-deck references against the current combined-manuscript AUX.
+Labeled `equation` environments receive matching explicit number tags; missing
+canonical numbers or conflicting authored tags fail rendering. Standalone
+authoring and archive mode retain their existing local numbering behavior.
+
 For dense manuscript figures, use the explicit `data-slide-manifest`
 [panel contract](README.md#source-bound-presentation-panels) to select ordered,
 source-bound presentation rasters. The producer supplies each raster digest,

--- a/infrastructure/rendering/_slides_crossref.py
+++ b/infrastructure/rendering/_slides_crossref.py
@@ -17,7 +17,9 @@ This module provides the parsing and substitution pass used by
 * :func:`resolve_cross_deck_references` rewrites ``\\ref{L}`` to the
   literal printed number (and ``\\eqref{L}`` to ``(N)``) for every label
   ``L`` that is **not** defined inside the deck's own ``.tex`` source.
-  Within-deck references are left alone so Beamer numbers them natively;
+  Within-deck references are left alone by default. Canonical accessible
+  refreshes resolve them from the same AUX and bind displayed, labeled
+  ``equation`` environments to that number with an explicit amsmath tag;
   labels absent from the aux map are left untouched and reported back to
   the caller. Direct standalone renders remain fail-open, while the canonical
   post-combined refresh rejects unresolved non-section labels in strict mode.
@@ -37,6 +39,7 @@ import re
 from collections.abc import Callable
 from pathlib import Path
 
+from infrastructure.core.exceptions import RenderingError
 from infrastructure.core.logging.utils import get_logger
 
 logger = get_logger(__name__)
@@ -268,3 +271,48 @@ def resolve_cross_deck_references(
 
     updated = transform_tex_prose(tex_content, _resolve_segment)
     return updated, replaced, sorted(unresolved)
+
+
+def bind_displayed_equation_numbers(tex_content: str, label_numbers: dict[str, str]) -> str:
+    """Bind labeled single-number equations to the canonical manuscript AUX.
+
+    Strict accessible decks resolve prose references against the combined PDF.
+    Their displayed equations must use the same numbers instead of restarting
+    at one in each standalone Beamer build. Only numbered ``equation``
+    environments are transformed; unnumbered mathematics remains unchanged.
+    Literal examples and comments are excluded without losing source offsets.
+    Missing or conflicting labels and authored tags fail closed.
+    """
+    masked = list(tex_content)
+    for start, end in _tex_literal_ranges(tex_content):
+        masked[start:end] = " " * (end - start)
+    prose = "".join(masked)
+    equation_re = re.compile(r"\\begin\{equation\}(?P<body>.*?)\\end\{equation\}", re.DOTALL)
+    tag_re = re.compile(r"\\tag(?P<star>\*)?\{(?P<number>[^{}]*)\}")
+    insertions: list[tuple[int, str]] = []
+    for equation in equation_re.finditer(prose):
+        body = equation.group("body")
+        labels = _LABEL_RE.findall(body)
+        if not labels:
+            continue
+        numbers = {label_numbers.get(label) for label in labels}
+        if len(numbers) != 1 or None in numbers:
+            raise RenderingError(
+                "Current combined-manuscript AUX cannot bind displayed slide equation",
+                context={"equation_labels": labels},
+            )
+        number = next(iter(numbers))
+        if number is None or not _SAFE_NUMBER_RE.fullmatch(number):
+            raise RenderingError("Unsafe canonical slide equation number", context={"equation_labels": labels})
+        tags = list(tag_re.finditer(body))
+        if tags:
+            if len(tags) != 1 or tags[0].group("number") != number:
+                raise RenderingError(
+                    "Authored slide equation tag conflicts with canonical manuscript numbering",
+                    context={"equation_labels": labels},
+                )
+            continue
+        insertions.append((equation.start("body"), rf"\tag{{{number}}}"))
+    for position, text in reversed(insertions):
+        tex_content = tex_content[:position] + text + tex_content[position:]
+    return tex_content

--- a/infrastructure/rendering/ide_style.css
+++ b/infrastructure/rendering/ide_style.css
@@ -286,6 +286,12 @@ mjx-container[display="true"] {
 }
 
 @media (min-width: 1000px) {
+  /* Wide figure links stay within the viewport but extend beyond the prose
+     column. Do not clip their labels at the narrower body boundary. */
+  body {
+    overflow-x: visible;
+  }
+
   .figure-full-size-link {
     left: 50%;
     max-width: none;

--- a/infrastructure/rendering/slides_renderer.py
+++ b/infrastructure/rendering/slides_renderer.py
@@ -36,6 +36,7 @@ from infrastructure.core.files.secure_write import atomic_write_text_confined
 from infrastructure.core.logging.utils import get_logger
 from infrastructure.rendering._slides_crossref import (
     COMBINED_AUX_BASENAME,
+    bind_displayed_equation_numbers,
     parse_aux_label_numbers,
     resolve_cross_deck_references,
     transform_tex_prose,
@@ -666,7 +667,7 @@ class SlidesRenderer:
         (``{pdf_dir}/_combined_manuscript.aux``); this pre-pass replaces
         each cross-deck reference with the literal number that aux
         recorded — the same number the combined PDF prints. Within-deck
-        references are untouched (Beamer numbers them natively), labels
+        references are untouched by default (Beamer numbers them natively), labels
         missing from the aux are left as-is and noted in the render log,
         and a missing aux (e.g. first-ever render, before any combined
         build) skips only the numeric lookup. In the accessible profile,
@@ -677,10 +678,14 @@ class SlidesRenderer:
         The default standalone pass remains fail-open. The producer-ordered
         refresh sets ``strict_cross_deck_refs`` and, in accessible mode, fails
         when any reference (including a local section reference) is absent
-        from the current combined-manuscript AUX.
+        from the current combined-manuscript AUX. That strict accessible pass
+        also tags labeled single-number equations with their canonical numbers
+        so the visible equation and its prose references agree.
         """
         aux_path = Path(self.config.pdf_dir) / COMBINED_AUX_BASENAME
         label_numbers = parse_aux_label_numbers(aux_path)
+        if self.config.slides_profile == "accessible" and strict_cross_deck_refs:
+            tex_content = bind_displayed_equation_numbers(tex_content, label_numbers)
         missing_accessible_sections: set[str] = set()
         accessible_section_replacements = 0
         if self.config.slides_profile == "accessible":

--- a/tests/infra_tests/rendering/test_slides_crossref.py
+++ b/tests/infra_tests/rendering/test_slides_crossref.py
@@ -16,6 +16,7 @@ real aux-format lines (samples mirror an actual
 from __future__ import annotations
 
 import subprocess
+import shutil
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,7 @@ import pytest
 from infrastructure.core.exceptions import RenderingError
 from infrastructure.rendering._slides_crossref import (
     COMBINED_AUX_BASENAME,
+    bind_displayed_equation_numbers,
     parse_aux_label_numbers,
     resolve_cross_deck_references,
 )
@@ -46,6 +48,95 @@ _REAL_AUX = "\n".join(
         r"\newlabel{sec:appendix-proofs}{{A.2}{41}{Proofs}{appendix.A.2}{}}",
     ]
 )
+
+
+def test_displayed_equation_numbers_preserve_literals_and_nested_math():
+    literal = (
+        "% \\begin{equation}\\label{eq:comment}x=0\\end{equation}\n"
+        r"\begin{verbatim}\begin{equation}\label{eq:code}x=0\end{equation}\end{verbatim}"
+        r"\verb|\begin{equation}\label{eq:inline}x=0\end{equation}|"
+    )
+    equation = (
+        "\\begin{equation}% retained comment\n"
+        r"\protect\phantomsection\label{eq:model}{\begin{aligned}x&=1\\y&=2\end{aligned}}"
+        r"\end{equation}"
+    )
+    result = bind_displayed_equation_numbers(literal + equation, {"eq:model": "A.7"})
+    assert result == literal + equation.replace(r"\begin{equation}", r"\begin{equation}\tag{A.7}", 1)
+    assert bind_displayed_equation_numbers(result, {"eq:model": "A.7"}) == result
+
+
+@pytest.mark.parametrize(
+    "body,numbers",
+    [
+        (r"\label{eq:missing}x=1", {}),
+        (r"\label{eq:a}\label{eq:b}x=1", {"eq:a": "2", "eq:b": "3"}),
+        (r"\label{eq:a}\tag{1}x=1", {"eq:a": "2"}),
+        (r"\label{eq:a}x=1", {"eq:a": r"\unsafe"}),
+    ],
+)
+def test_displayed_equation_numbers_reject_missing_or_conflicting_authority(body, numbers):
+    with pytest.raises(RenderingError):
+        bind_displayed_equation_numbers(r"\begin{equation}" + body + r"\end{equation}", numbers)
+
+
+def test_displayed_equation_numbers_leave_unnumbered_and_unlabeled_math():
+    tex = r"\begin{equation*}\label{eq:a}x=1\end{equation*}\begin{equation}y=2\end{equation}"
+    assert bind_displayed_equation_numbers(tex, {}) == tex
+
+
+def test_displayed_equation_numbers_preserve_matching_authored_tag_style():
+    tex = r"\begin{equation}\label{eq:a}\tag*{A.7}x=1\end{equation}"
+    assert bind_displayed_equation_numbers(tex, {"eq:a": "A.7"}) == tex
+
+
+@pytest.mark.parametrize("profile,strict", [("archive", True), ("accessible", False)])
+def test_noncanonical_render_keeps_native_equation_numbering(tmp_path, profile, strict):
+    pdf_dir = tmp_path / "pdf"
+    pdf_dir.mkdir()
+    (pdf_dir / COMBINED_AUX_BASENAME).write_text(r"\newlabel{eq:a}{{7}{1}}", encoding="utf-8")
+    renderer = SlidesRenderer(RenderingConfig(pdf_dir=str(pdf_dir), slides_profile=profile))
+    tex = r"\begin{equation}\label{eq:a}x=1\end{equation} See \eqref{eq:a}."
+    assert renderer._resolve_cross_deck_refs(tex, strict_cross_deck_refs=strict) == tex
+
+
+@pytest.mark.slow
+def test_canonical_equation_tags_match_references_in_real_beamer_pdf(tmp_path):
+    """A standalone deck must not print (1) while its prose points to (7)."""
+    if shutil.which("xelatex") is None or shutil.which("pdftotext") is None:
+        pytest.skip("xelatex and pdftotext are required for the real PDF regression")
+    tex = (
+        r"\documentclass{beamer}\usepackage{amsmath}\begin{document}"
+        r"\begin{frame}{Canonical numbering}"
+        r"\begin{equation}\label{eq:first}x=1\end{equation}"
+        r"See first \eqref{eq:first}."
+        r"\begin{equation}\label{eq:second}y=2\end{equation}"
+        r"See second \eqref{eq:second}.\end{frame}\end{document}"
+    )
+    numbers = {"eq:first": "7", "eq:second": "12"}
+    tex = bind_displayed_equation_numbers(tex, numbers)
+    tex, _, unresolved = resolve_cross_deck_references(tex, numbers, resolve_local=True)
+    assert not unresolved
+    path = tmp_path / "canonical.tex"
+    path.write_text(tex, encoding="utf-8")
+    subprocess.run(
+        ["xelatex", "-halt-on-error", "-interaction=nonstopmode", path.name],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    result = subprocess.run(
+        ["pdftotext", str(path.with_suffix(".pdf")), "-"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.stdout.count("(7)") == 2
+    assert result.stdout.count("(12)") == 2
+    assert "(1)" not in result.stdout and "(2)" not in result.stdout
 
 
 class TestParseAuxLabelNumbers:
@@ -334,6 +425,7 @@ class TestSlidesRendererHook:
 
         assert r"\label{eq:model}" in updated
         assert "See Equation (7)." in updated
+        assert r"\tag{7}" in updated
         assert r"\eqref{eq:model}" not in updated
 
     def test_accessible_strict_profile_rejects_section_missing_from_aux(self, tmp_path):


### PR DESCRIPTION
Accessible publication surfaces had two visible inconsistencies: section decks could display equation `(1)` beside a canonical reference to `(7)`, and desktop HTML clipped widened scientific figures at the narrower prose-column boundary.

The strict accessible refresh now tags each labeled single-number `equation` environment from the combined manuscript AUX. Missing or conflicting canonical numbers and conflicting authored tags fail rendering. Comments, literal code, unnumbered mathematics, matching authored tags, standalone authoring, and archive numbering retain their behavior. Desktop CSS permits the figure link to extend beyond the prose column within the viewport, retaining responsive narrow layouts and local table scrolling. Renderer documentation records both contracts.

Validation:

- Equation regression failed before the fix and passed afterward. All 36 focused checks passed, including real XeLaTeX/PDF verification of displayed and referenced `(7)` and `(12)`.
- Rendering suite: 1,743 fast tests passed initially; two subprocess tests passed after correcting the interpreter PATH. Four fast tests skipped. All 105 slow tests passed, with one skip.
- The final web-renderer and cross-reference selection passed 102 tests, with one slow case deselected; that real compiler case was separately verified.
- A real-browser desktop ancestor-clipping regression failed on the original HTML. After CSS embedding, all 135 desktop, 200% zoom, and 400% zoom checks passed across 45 downstream reader pages, including keyboard focus and disclosure checks. The corrected desktop viewport was visually inspected.
- Real downstream Beamer/Reveal previews produced three pairs with matching displayed/reference numbers on the inspected pages.
- Public `template_code_project` Stage 03 completed successfully after the rendering suite. Full public Ruff/mypy scopes and all 26 repository health gates passed before the final CSS/documentation correction; hosted CI validates the final commit.
