### PR TITLE
Keep equation numbers visible after live browser zoom

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -143,6 +143,7 @@ A negative control backs this contract: deliberately breaking any represented st
 - **Matrix:** `ubuntu-latest` × `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, plus an `include:` of `macos-latest` × `3.14` (6 cells). macOS legs are ~10x cost and rarely surface OS-specific breakage beyond the 3.14 cell, so only the 3.14 smoke runs there.
 - **Coverage threshold:** 60% (`--cov-fail-under=60`)
 - **Coverage file:** `.coverage.infra` (isolated from project coverage)
+- **Browser reflow:** the Ubuntu/Python 3.14 cell runs the real Chromium MathJax regression after infrastructure tests. It provisions `@playwright/test@1.62.1` and Chromium, waits for completed typesetting, and verifies visible equation numbers across live viewport changes. CDN access is required; a browser or MathJax failure fails the cell.
 - **Exclusions:** Tests marked `requires_ollama` are skipped (`-m "not requires_ollama"`)
 - **Codecov upload:** On Python 3.14 / `ubuntu-latest` only to avoid duplicate reports; upload failures do not fail CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,17 @@ jobs:
           -m "not requires_ollama and not requires_docker and not network and not slow and not bench and not benchmark and not performance"
           --timeout=120
 
+      - name: Verify completed MathJax equations across live viewport changes
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
+        run: |
+          export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+          npm install --prefix .tmp/playwright-node --no-package-lock --no-save @playwright/test@1.62.1
+          .tmp/playwright-node/node_modules/.bin/playwright install --with-deps chromium
+          NODE_PATH="$PWD/.tmp/playwright-node/node_modules" \
+            .tmp/playwright-node/node_modules/.bin/playwright test \
+            tests/infra_tests/rendering/mathjax_reflow.spec.cjs \
+            --workers=1 --output=.tmp/mathjax-browser
+
       - name: Upload infrastructure coverage to Codecov
         if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/infrastructure/rendering/README.md
+++ b/infrastructure/rendering/README.md
@@ -652,7 +652,11 @@ unsafe paths, malformed or mismatched identifiers, and then adds a contextual
 link to the source-generated Markdown table. This makes the numerical fallback
 discoverable without copying values into rendering code. In manuscript HTML,
 wide tables are wrapped in labelled, keyboard-focusable scroll regions; code
-and displayed mathematics retain their own scroll regions. The page body uses
+wraps and displayed mathematics uses MathJax line breaking. The shared MathJax
+configuration recalculates container metrics after viewport-width changes,
+including zoom after the first render, and serializes asynchronous reflows.
+Browser checks must await initial typesetting, pending reflow, fonts, and images
+before measuring geometry. The page body uses
 no horizontal scroll at reflow zoom, and every full-size figure link is named
 from its numbered caption or concise alternative.
 

--- a/infrastructure/rendering/_web_assets.py
+++ b/infrastructure/rendering/_web_assets.py
@@ -56,8 +56,41 @@ window.normalizeTemplateMathJaxAria = function () {{
 }};
 window.MathJax.startup = Object.assign({{}}, window.MathJax.startup, {{
   ready: function () {{
+    var measuredWidth = document.documentElement.clientWidth;
+    var reflowQueued = false;
     window.MathJax.startup.defaultReady();
-    window.MathJax.startup.promise.then(window.normalizeTemplateMathJaxAria);
+    window.templateMathJaxReflowPromise = window.MathJax.startup.promise.then(
+      window.normalizeTemplateMathJaxAria
+    );
+    function reflowDisplayMath() {{
+      if (reflowQueued || document.documentElement.clientWidth === measuredWidth) return;
+      reflowQueued = true;
+      window.templateMathJaxReflowPromise = window.templateMathJaxReflowPromise
+        .catch(function () {{ /* A later resize may retry a failed render. */ }})
+        .then(async function () {{
+          var width = document.documentElement.clientWidth;
+          try {{
+            // MathJax 4 MathItem.STATE.METRICS = 110. The default RERENDER
+            // state retains old container metrics and cannot reflow on zoom.
+            await window.MathJax.startup.document.rerenderPromise(110);
+            window.normalizeTemplateMathJaxAria();
+            window.templateMathJaxReflowError = null;
+          }} catch (error) {{
+            window.templateMathJaxReflowError = String(error);
+            console.error("MathJax viewport reflow failed", error);
+            throw error;
+          }} finally {{
+            measuredWidth = width;
+            reflowQueued = false;
+          }}
+        }})
+        .then(reflowDisplayMath);
+      // Keep failure observable to callers without an unhandled rejection.
+      window.templateMathJaxReflowPromise.catch(function () {{}});
+    }}
+    window.addEventListener("resize", reflowDisplayMath);
+    // Also cover a resize that happened during the initial asynchronous render.
+    window.templateMathJaxReflowPromise.then(reflowDisplayMath);
   }}
 }});
 </script>"""

--- a/tests/infra_tests/rendering/README.md
+++ b/tests/infra_tests/rendering/README.md
@@ -47,6 +47,24 @@ uv run pytest tests/infra_tests/rendering/test_web_renderer.py -v
 - Cross-reference handling
 - Style application
 
+The real Chromium regression in `mathjax_reflow.spec.cjs` typesets an equation
+through the shared pinned MathJax configuration, then changes the viewport from
+desktop to 200% and 400% equivalent widths and back. It checks visible equation
+numbers, unchanged input mathematics, and document width after asynchronous
+typesetting completes. It runs in the Ubuntu/Python 3.14 infrastructure CI cell.
+Run it locally from the repository root with:
+
+```bash
+npm install --prefix .tmp/playwright-node --no-package-lock --no-save @playwright/test@1.62.1
+.tmp/playwright-node/node_modules/.bin/playwright install chromium
+NODE_PATH="$PWD/.tmp/playwright-node/node_modules" \
+  .tmp/playwright-node/node_modules/.bin/playwright test \
+  tests/infra_tests/rendering/mathjax_reflow.spec.cjs \
+  --workers=1 --output=.tmp/mathjax-browser
+```
+
+The probe requires the pinned MathJax CDN assets; it is not an offline test.
+
 ### Slide Renderer Tests
 
 The slide contract is partitioned across `test_slides_renderer_core.py`,

--- a/tests/infra_tests/rendering/mathjax_reflow.spec.cjs
+++ b/tests/infra_tests/rendering/mathjax_reflow.spec.cjs
@@ -1,0 +1,57 @@
+const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
+const { pathToFileURL } = require("node:url");
+const { expect, test } = require("@playwright/test");
+
+async function settleMath(page) {
+  await page.waitForFunction(() => typeof window.MathJax?.startup?.document?.rerenderPromise === "function");
+  await page.evaluate(async () => {
+    await window.MathJax.startup.promise;
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    await window.templateMathJaxReflowPromise;
+    await document.fonts.ready;
+  });
+}
+
+test("display equations retain visible numbers after live viewport resizing", async ({ page }, testInfo) => {
+  test.setTimeout(90000);
+  const file = testInfo.outputPath("math-reflow.html");
+  fs.mkdirSync(testInfo.outputDir, { recursive: true });
+  const html = String.raw`<!doctype html><html lang="en"><head><meta charset="utf-8">
+    <style>body { margin: 0; padding: 16px; overflow-x: clip; font-size: 16px; }</style>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@4.0.0/tex-chtml.js"></script>
+    </head><body><h1>Equation reflow</h1><p><span class="math display">\[
+    u_{n+1}=a_1x_1+a_2x_2+a_3x_3+a_4x_4+a_5x_5+a_6x_6+a_7x_7+a_8x_8
+    \qquad{(17)}\]</span></p></body></html>`;
+  fs.writeFileSync(file, html);
+  const code = "from pathlib import Path; import sys; from infrastructure.rendering._web_assets import harden_mathjax_script; harden_mathjax_script(Path(sys.argv[1]))";
+  const result = spawnSync("uv", ["run", "--locked", "python", "-c", code, file], { encoding: "utf8" });
+  expect(result.status, result.stdout + result.stderr).toBe(0);
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto(pathToFileURL(file).href, { waitUntil: "domcontentloaded" });
+  await settleMath(page);
+  const source = await page.evaluate(() => MathJax.startup.document.getMathItemsWithin(document.body).map((item) => item.math));
+  expect(source).toHaveLength(1);
+  for (const width of [640, 320, 1440, 320]) {
+    await page.setViewportSize({ width, height: 900 });
+    await settleMath(page);
+    const geometry = await page.evaluate(() => ({
+      width: innerWidth,
+      body: document.body.scrollWidth,
+      error: window.templateMathJaxReflowError || null,
+      source: MathJax.startup.document.getMathItemsWithin(document.body).map((item) => item.math),
+      math: [...document.querySelectorAll("mjx-math")].map((element) => ({
+        left: element.getBoundingClientRect().left,
+        right: element.getBoundingClientRect().right,
+        text: element.textContent,
+      })),
+    }));
+    expect(geometry.error).toBeNull();
+    expect(geometry.source).toEqual(source);
+    expect(geometry.body).toBeLessThanOrEqual(width + 1);
+    expect(geometry.math).toHaveLength(1);
+    expect(geometry.math[0].text).toContain("(17)");
+    expect(geometry.math[0].left).toBeGreaterThanOrEqual(-1);
+    expect(geometry.math[0].right).toBeLessThanOrEqual(width + 1);
+  }
+});


### PR DESCRIPTION
Display equations kept their original container metrics after browser zoom, allowing equation numbers to fall beyond the visible page. The shared MathJax startup hook now serializes viewport-triggered reflows from the metrics stage, preserving the original equation input and reapplying the existing speech/ARIA normalization. Failed reflows remain observable and a later resize can retry them.

A real Chromium regression loads the canonical pinned MathJax configuration, waits for completed typesetting, and checks unchanged equation input, visible numbering, and page width through desktop, 200%, 400%, and return transitions. The Ubuntu/Python 3.14 infrastructure cell runs this test; CDN access remains required.

Validation on `0c12aa962891669c9a192c2d56a0f007fe7a8812`:

- Rendering: 1,748 fast tests passed, 4 skipped; 106 slow tests passed, including real LaTeX rendering.
- The new Chromium regression passed and failed as expected against the exact previous renderer commit.
- All 26 repository health gates passed on the clean commit, including public-scope lint, formatting, and type checking. Actionlint passed.
- The outgoing history audit found no secrets or unresolved findings; its only gitlink is unchanged from the base.

Independent adversarial review passed on this exact head and tree `67f105468b76eea1c606274796bf6215a9d04ab4`, with no actionable findings. In addition to the committed regression and seven focused Python tests, a separate 24-equation probe passed resize-during-startup and repeated rapid transitions while preserving all input equations and 24 speech nodes. The exact-base negative control reproduced a 526-pixel equation edge in a 320-pixel viewport. Review covered promise rejection/retry behavior, ARIA preservation, and the CI trust boundary. This is independent software review, not scientific independence or accessibility conformance.

A downstream private preview using the canonical candidate configuration passed all 180 checks across 45 manuscript pages, including completed desktop, initial narrow, and live zoom transitions. The prior attempt retained two initial-typesetting timeouts; the unchanged full rerun passed in 3.2 minutes. Their cause is not conclusively diagnosed and the CDN dependency remains explicit. This preview is separate from downstream final production and publication certification.
