### PR TITLE
Preserve exact-commit CI evidence and isolate push-hook Git environments

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -52,7 +52,7 @@ flowchart TB
 ### CI Pipeline (`workflows/ci.yml`)
 
 **Triggers:** push to `main`, pull requests targeting `main`, weekly scheduled run (Sunday midnight UTC), manual **`workflow_dispatch`** (no inputs).
-**Concurrency:** Running builds for the same ref are cancelled when a new commit arrives.
+**Concurrency:** Superseded PR runs are cancelled by PR ref. Main pushes, scheduled runs, and manual runs each retain a unique run group so later commits cannot cancel exact-commit verification.
 
 **Pipeline jobs** (job ids in `ci.yml`; display names differ — use `name:` for branch protection):
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -34,7 +34,7 @@ flowchart LR
 | `schedule` | Weekly Sunday midnight UTC (CVE catch-up) |
 | `workflow_dispatch` | Manual trigger (no inputs) |
 
-**Concurrency:** `cancel-in-progress: true` — stale runs are cancelled automatically when a new commit is pushed.
+**Concurrency:** PR runs share a group by PR ref and cancel superseded runs. Push, scheduled, and manual runs use their unique `github.run_id` and do not cancel other runs, preserving exact-commit post-merge evidence while `main` advances. GitHub runner availability still bounds job execution; this policy does not guarantee completion or permit a cancelled run to count as green. Historical reruns retain their original workflow and concurrency group: avoid running two old-policy main workflows concurrently during exact-commit certification. The first new-policy PR run also has a different group from any pre-policy run of that PR.
 
 **Global env:** `UV_FROZEN=true`, `MPLBACKEND=Agg` (non-interactive matplotlib backend).
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  # Preserve completed-SHA evidence even while other main commits arrive.
+  # Only superseded runs of the same pull request cancel each other.
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   UV_FROZEN: "true"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,6 +142,7 @@ repos:
           - >-
             export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH" &&
             export PYTHONDONTWRITEBYTECODE=1 &&
+            unset $(git rev-parse --local-env-vars) &&
             uv run python scripts/audit/check_tracked_generated_artifacts.py &&
             uv run python scripts/audit/check_tracked_secrets.py &&
             uv run python scripts/audit/check_tracked_all.py &&
@@ -173,6 +174,7 @@ repos:
           - >-
             export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH" &&
             export PYTHONDONTWRITEBYTECODE=1 &&
+            unset $(git rev-parse --local-env-vars) &&
             uv run python scripts/audit/check_template_drift.py --strict &&
             uv run python scripts/audit/check_backlog.py &&
             uv run python scripts/audit/check_claim_bindings.py &&

--- a/tests/infra_tests/git_hook_smoke/README.md
+++ b/tests/infra_tests/git_hook_smoke/README.md
@@ -12,6 +12,7 @@ uv run pytest tests/infra_tests/git_hook_smoke/ -q --import-mode=importlib
 
 | File | Purpose |
 | --- | --- |
+| `test_hook_git_environment.py` | Real nested-Git index isolation, with an unsafe-prefix negative control |
 | `test_gate.py` | Project discovery, pipeline config, import, validation CLI smoke |
 | `test_tracked_generated_artifacts.py` | Generated-artifact guard regression tests |
 
@@ -19,3 +20,8 @@ uv run pytest tests/infra_tests/git_hook_smoke/ -q --import-mode=importlib
 
 - [`AGENTS.md`](AGENTS.md)
 - [`../README.md`](../README.md)
+
+The push smoke and documentation hooks clear Git repository-local variables in
+their child shell before running commands that create temporary repositories.
+The staged-secret hook retains its index environment so it checks the actual
+staged content. See [Git hook environment guidance](https://git-scm.com/docs/githooks).

--- a/tests/infra_tests/git_hook_smoke/test_hook_git_environment.py
+++ b/tests/infra_tests/git_hook_smoke/test_hook_git_environment.py
@@ -1,0 +1,48 @@
+"""Real Git regressions for repository-local variables inherited by push hooks."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.parametrize("hook_id", ["pre-push-quick", "docs-contract-guard"])
+@pytest.mark.parametrize("isolated", [True, False], ids=["configured-hook", "negative-control"])
+def test_hook_subprocess_preserves_caller_index(tmp_path: Path, hook_id: str, isolated: bool) -> None:
+    """Nested Git writes its own index; the old prefix demonstrates the hazard."""
+    root = Path(__file__).resolve().parents[3]
+    config = yaml.safe_load((root / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    hook = next(hook for repo in config["repos"] for hook in repo["hooks"] if hook["id"] == hook_id)
+    prefix, separator, _ = hook["args"][-1].partition("uv run ")
+    assert separator
+    isolation = "unset $(git rev-parse --local-env-vars) && "
+    assert isolation in prefix
+    if not isolated:
+        prefix = prefix.replace(isolation, "", 1)
+
+    # Never let the test's own setup inherit the invoking repository's index.
+    clean_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    caller, nested = tmp_path / "caller", tmp_path / "nested"
+    for repo in (caller, nested):
+        repo.mkdir()
+        subprocess.run(["git", "init", "--quiet", str(repo)], env=clean_env, check=True, timeout=30)
+        (repo / "file.txt").write_text(repo.name, encoding="utf-8")
+        subprocess.run(["git", "-C", str(repo), "add", "file.txt"], env=clean_env, check=True, timeout=30)
+    caller_index, nested_index = caller / ".git/index", nested / ".git/index"
+    caller_before, nested_before = caller_index.read_bytes(), nested_index.read_bytes()
+    inherited = dict(
+        clean_env, GIT_DIR=str(caller / ".git"), GIT_WORK_TREE=str(caller), GIT_INDEX_FILE=str(caller_index)
+    )
+    subprocess.run(
+        ["bash", "-eo", "pipefail", "-c", prefix + 'git -C "$1" read-tree --empty', "hook-probe", str(nested)],
+        cwd=caller,
+        env=inherited,
+        check=True,
+        timeout=30,
+    )
+    assert (caller_index.read_bytes() == caller_before) is isolated
+    assert (nested_index.read_bytes() != nested_before) is isolated


### PR DESCRIPTION
A later main push could cancel a still-required CI run for an earlier reviewed renderer commit. Non-PR runs now use a unique run-ID concurrency group with cancellation disabled; newer runs of the same PR still cancel superseded PR runs. All triggers, jobs, permissions, timeouts and quality thresholds remain unchanged. Historical reruns retain their original workflow configuration and can still collide with other historical runs; the documentation records that migration limit.

A real pre-push attempt also exposed inherited Git repository variables redirecting temporary-repository fixture writes into the caller index. The two hooks that execute nested repository tests or collection now clear Git's repository-local variables inside their child shell. The staged-secret hook retains its staged-index environment. Four real Git regression cases read the configured hook prefixes and verify both index isolation and the unsafe-prefix negative control inside temporary repositories.

Validation: Actionlint; the real GitHub expression evaluator across seven event contexts; 18 hook smoke tests; the complete documentation hook including generated counts; canonical public Ruff/format checks (2,952 files) and mypy (1,614 source files); commit hooks. Outgoing object and secret audits have zero unresolved findings. An unchanged inherited gitlink is explicitly accounted for. Independent adversarial review passed on exact commit `69956767ff4d82e803b430dd516ff4c46f53aafd`, tree `f9b8e442437711a4745178a3f52ca054c1a9f84a`. A normal local bare-remote push passed with all hooks enabled, the exact intended receiving ref, and a clean source worktree. Hosted CI remains required before normal merge.

All 26 canonical health gates passed on the clean exact candidate commit.

While hosted checks ran, main advanced to `083c953513b1beaec02a2554cd823d6ca1519f87`. Independent composition review verified the conflict-free prospective tree `04773c6d11c0b36feb14d0f07d714870dbbade4d`: all six reviewed files retain their exact approved blobs, and every other entry equals the new main. All 26 health gates and 23 focused hook/workflow-parity tests also passed in a disposable integration preview of that tree. This is additional tree-bound evidence; actual post-main CI remains required after normal merge.
