### PR TITLE
ci: scheduled slow lane for slow-marked infra tests (SLOW-PROFILE-1)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -56,10 +56,11 @@ flowchart TB
 
 **Pipeline jobs** (job ids in `ci.yml`; display names differ — use `name:` for branch protection):
 
-**16 jobs total; 2 are conditional on push/PR (fep-lean, setup-hook-windows-smoke), gated by the `detect` job's outputs
+**17 jobs total; 2 are conditional on push/PR (fep-lean, setup-hook-windows-smoke), gated by the `detect` job's outputs
 (`needs.detect.outputs.*`) — NOT a job-level `hashFiles()` (that is invalid
-in a job `if:` and rejects the whole workflow at parse). 1 further job
-(`public-matrix-receipt`) runs only on the weekly schedule or manual dispatch.**
+in a job `if:` and rejects the whole workflow at parse). 2 further jobs
+(`public-matrix-receipt`, `test-infra-slow`) run only on the weekly schedule
+or manual dispatch.**
 
 | # | Job id | Display name (representative) | Depends on | Python | Runner |
 | --- | --- | --- | --- | --- | --- |
@@ -79,6 +80,7 @@ in a job `if:` and rejects the whole workflow at parse). 1 further job
 | 14 | `docs-lint` | Documentation Lint | lint | 3.14 | ubuntu |
 | 15 | `performance` | Performance Check | test-infra + test-project | 3.14 | ubuntu |
 | 16 | `public-matrix-receipt` | Public Matrix Receipt (receipt-bearing full matrix) | — | 3.14 | ubuntu · schedule/manual only |
+| 17 | `test-infra-slow` | Infra Slow Lane (`pytest.mark.slow`) | verify-no-mocks | 3.14 | ubuntu · schedule/manual only — exercises the slow-marked suite PR lanes deselect |
 
 **Lint job** also runs `uv run python -m infrastructure.skills check-all-exports` (MED5 `__all__` gate), `scripts/audit/check_tracked_generated_artifacts.py` (rejects generated outputs and local `.codegraph/` indexes), **`scripts/audit/check_template_drift.py --strict`** (exemplar doc/script drift against Layer-1 contracts), and **`scripts/audit/check_tracked_all.py`** — the **confidentiality guard** that fails CI if any path outside the public allowlists for `projects/`, `fonds/`, `rules/`, or `tools/` is git-tracked (this is a public repo; confidential/rotating resources are local-only). **`validate`** runs manuscript markdown validation (one dir per invocation, looped over `projects/*/manuscript/`), `scripts/docgen/api_reference.py --check`, and imports each `projects.{name}.src`. **`security`** runs blocking **`pip-audit`** (IDs from [`.github/pip-audit-ignore.txt`](pip-audit-ignore.txt), up to 3 retries on failure) and **`bandit -c bandit.yaml -r -ll`** over `infrastructure/`, `scripts/`, and `projects/`. Path exclusions (`projects/working/`, `projects/ongoing/`, `projects/published/`, `projects/archive/`, `projects/other/`, plus `.venv`, `site-packages`, `.lake`, the vendored `infrastructure/steganography/kmyth` submodule, and named rotating research projects such as `projects/BeeStack` — **not** the rendered `projects/active/` mirror) live in [`bandit.yaml`](../bandit.yaml) (`exclude_dirs`).
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,65 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Job 3b — Infrastructure slow lane (scheduled/dispatch only)
+#
+# SLOW-PROFILE-1: the ~190 ``pytest.mark.slow`` infra tests (36 files; real
+# pandoc/LaTeX rendering, llm review generators over a local HTTP stub) never
+# ran on CI — the default marker expression deselects them on every lane. This
+# scheduled lane exercises the full slow suite so a broken slow-marked test
+# fails HERE, loudly, while PR lanes stay fast. ``slow`` has zero overlap with
+# the other opt-in markers (verified 2026-09-08), so a bare ``-m slow`` — which
+# overrides the pyproject default marker expression — selects exactly the
+# deferred suite.
+# ─────────────────────────────────────────────────────────────────────────────
+  test-infra-slow:
+    name: "Infra Slow Lane (pytest.mark.slow)"
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [verify-no-mocks]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-python-env
+
+      - name: Sync dependencies (dev + optional test groups)
+        run: uv sync --group public-exemplars
+
+      - name: Install pandoc
+        uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
+
+      - name: Cache TeX Live packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            /var/cache/apt
+            /usr/share/texlive
+            /usr/share/texmf
+          key: texlive-${{ runner.os }}-xetex-extra-bibtex-fonts-v1
+        id: texlive-cache
+
+      - name: Install TeX Live (xelatex + bibtex)
+        if: steps.texlive-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            texlive-xetex texlive-latex-extra texlive-bibtex-extra \
+            texlive-fonts-recommended lmodern
+
+      - name: Run slow-marked infrastructure tests
+        run: >-
+          uv run pytest tests/infra_tests/
+          -m slow
+          -n auto
+          --dist loadscope
+          --benchmark-disable
+          --durations=10
+          --timeout=1200
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Job — Regression tier (claim-binding pins across all public exemplars)
 # ─────────────────────────────────────────────────────────────────────────────
   test-regression:
@@ -1056,6 +1115,7 @@ jobs:
       - verify-no-mocks
       - setup-hook-windows-smoke
       - test-infra
+      - test-infra-slow
       - test-regression
       - test-project
       - fep-lean

--- a/docs/maintenance/ci-local.md
+++ b/docs/maintenance/ci-local.md
@@ -102,6 +102,7 @@ Add `.secrets` to `.gitignore` if you need to test secret-dependent jobs locally
 | `test-regression` (claim-binding pins) | ✅ Yes | Fully Linux-portable; needs `verify-no-mocks` |
 | `fep-lean` (gauss + lake, conditional) | ✅ Yes | Linux-only, `if: needs.detect.outputs.fep_lean == 'true'`; heavy (60 min timeout) |
 | `setup-hook-windows-smoke` | ❌ No | Runs on `windows-latest` — `act` only reproduces Linux containers; treat the real CI run as source of truth (same caveat as the macOS jobs above) |
+| `test-infra-slow` (`pytest.mark.slow` lane, schedule/manual only) | ✅ Yes | `uv run pytest tests/infra_tests/ -m slow` locally; heavy real-render suite (pandoc + TeX Live), no coverage upload |
 
 ## Fallback: fail-closed direct commands
 

--- a/docs/security/branch-protection-checklist.md
+++ b/docs/security/branch-protection-checklist.md
@@ -35,6 +35,7 @@ always-running blocking jobs declared by the current `ci.yml` are:
 | Setup hook (Windows smoke) | `setup-hook-windows-smoke` | Skipped (not failed) when no project ships `setup_hook.py` |
 | fep_lean (gauss + lake) | `fep-lean` | Skipped when the optional local project is absent |
 | Public Matrix Receipt | `public-matrix-receipt` | Runs only for scheduled or manually dispatched CI, not pull requests |
+| Infra Slow Lane (`pytest.mark.slow`) | `test-infra-slow` | Runs only for scheduled or manually dispatched CI, not pull requests |
 
 Do not require a context that is absent from normal pull-request events. Also
 review the list after workflow or matrix changes: a copied static checklist is


### PR DESCRIPTION
Row: `SLOW-PROFILE-1` (Medium — pytest slow marker + CI test-infra lane)

## What / why
The `\~190` `pytest.mark.slow` infrastructure tests (36 files: real pandoc/LaTeX rendering, llm review generators over a local HTTP stub) never ran on CI — the default marker expression deselects them on every lane, so a slow-marked regression could land silently. This adds a `test-infra-slow` job gated to `schedule`/`workflow_dispatch` that exercises the full slow suite while PR lanes stay fast (the row's negative control: a broken slow test fails the scheduled lane only).

## Change
- New `test-infra-slow` job in `.github/workflows/ci.yml`: mirrors `test-infra` provisioning (pandoc + TeX Live cache) and runs `uv run pytest tests/infra_tests/ -m slow -n auto --dist loadscope --benchmark-disable --durations=10 --timeout=1200`.
- An explicit `-m slow` overrides the pyproject default marker expression; verified `slow` has zero overlap with the other opt-in markers (bench/benchmark/performance/long_running/private_project/external_fixture all collect 0 combined with `slow`), so the bare marker selects exactly the deferred suite.
- Wired into `ci-gate` `needs` (skipped = ok on push/PR, per the gate's existing jq contract).
- Docs lock-step: `.github/AGENTS.md` job inventory (16 → 17 jobs), `docs/security/branch-protection-checklist.md` conditional-jobs table, `docs/maintenance/ci-local.md` act-coverage table.

## Verification
- Local slow lane: `uv run pytest tests/infra_tests/ -m slow -n 6 --dist loadscope --benchmark-disable --timeout=1200` → **190 passed in 76.92s**.
- Collection: `uv run pytest tests/infra_tests/ -m slow --collect-only -q` → 190 collected (> 0 per row acceptance).
- Hosted evidence: CI dispatched via `workflow_dispatch` on this branch; the `Infra Slow Lane` job result is cited in the TO-DO/CHANGELOG evidence commit before merge.
- Backlog gate: `uv run python scripts/audit/check_backlog.py --strict` green; row removal + CHANGELOG evidence lands in the pre-merge commit per the backlog contract.